### PR TITLE
Switch back to https URL for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "extern/ion-definitions"]
 	path = extern/ion-definitions
-	url = git@github.com:ooici/ion-definitions.git
+	url = https://github.com/ooici/ion-definitions.git


### PR DESCRIPTION
You can't do an anonymous checkout with the ssh protocol url, which
makes it difficult to do a deployment without passing along github
credentials.

I realize this can be a bit annoying, since git will ask you for your username/password each time you want to push, but you can avoid this by creating a .netrc file like the following:

```
$ cat ~/.netrc:
machine github.com
login yourusername
password secretpassword
```
