### PR TITLE
allow assignment of mocked clients by returning the result

### DIFF
--- a/pyon/util/unit_test.py
+++ b/pyon/util/unit_test.py
@@ -65,6 +65,7 @@ class PyonTestCase(unittest.TestCase):
                         mock=Mock(name='self.clients.%s.%s' % (dep_name,
                             func_name)), skipfirst=True)
                 setattr(mock_service, func_name, mock_func)
+        return self.clients
 
     # Assuming your service is the only subclass of the Base Service
     def test_verify_service(self):


### PR DESCRIPTION
Allows more understandable code in a unit test:

``` python
def setUp(self):
    # Create an IonObject mock for the examples/bank/trade_service.py module.
    #  the argument is the scope + ".IonObject"
    self.mock_ionobj = self._create_IonObject_mock('examples.bank.trade_service.IonObject')

    # Create mocks for all services (clients) used in the service named "trade"
    #   they will also be saved to self.clients
    mocked_trade_service_clients = self._create_service_mock('trade')

    # Create an instance of the service we want to test
    self.trade_service = TradeService()

    # replace the trade service's clients with the mocked clients
    self.trade_service.clients = mocked_trade_service_clients

    # Rename methods we'll use, to save some typing
    #   * It's also acceptable to say this as:
    #     self.mock_create = mocked_trade_service_clients.resource_registry.create
    self.mock_create = self.trade_service.clients.resource_registry.create

```

This avoids the confusing behavior that happened previously, where self.clients and self.resource_registry (and whatever other mocked services) magically appear as class-level variables.
