### PR TITLE
fixed missing newline in report for 'not implemented' messages

### DIFF
--- a/scripts/generate_interfaces.py
+++ b/scripts/generate_interfaces.py
@@ -725,7 +725,7 @@ def main():
                         added_class_names = True
                         validation_results += "\nBase service: %s\n" % base_subtype_name
                         validation_results += "Impl subtype: %s\n" % impl_subtype_name
-                    validation_results += "  Method '%s' not implemented" % key
+                    validation_results += "  Method '%s' not implemented\n" % key
                 else:
                     base_params = inspect.getargspec(compare_methods[key])
                     impl_params = inspect.getargspec(impl_subtype.__dict__[key])


### PR DESCRIPTION
This message needs a newline, like on line 738:
https://github.com/ooici/pyon/blob/master/scripts/generate_interfaces.py#L738
