### PR TITLE
prevent incorrect "OK" message in interface validation output

### DIFF
--- a/scripts/generate_interfaces.py
+++ b/scripts/generate_interfaces.py
@@ -721,6 +721,7 @@ def main():
             found_error = False
             for key in compare_methods:
                 if key not in impl_subtype.__dict__:
+                    found_error = True
                     if not added_class_names:
                         added_class_names = True
                         validation_results += "\nBase service: %s\n" % base_subtype_name
@@ -731,6 +732,7 @@ def main():
                     impl_params = inspect.getargspec(impl_subtype.__dict__[key])
 
                     if base_params != impl_params:
+                        found_error = True
                         if not added_class_names:
                             added_class_names = True
                             validation_results += "\nBase service: %s\n" % base_subtype_name


### PR DESCRIPTION
added what seem to be missing lines that prevent duplicate messages about service validation.

currently, found_error is initialized, but never assigned to.
https://github.com/ooici/pyon/blob/master/scripts/generate_interfaces.py#L721

when an error is detected, the service report is printed once with the error and once again with "OK".  

this patch suppresses the "OK" message if there is an error by putting in the "found_error = True" lines that were probably intended to be there in the first place.
