### PR TITLE
RPC messages send IonObject, op in headers instead of dict

### DIFF
--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -15,6 +15,7 @@ import yaml
 
 from pyon.core.path import list_files_recursive
 from pyon.util.log import log
+from pyon.util import yaml_ordered_dict
 
 class IonObjectError(Exception):
     pass

--- a/pyon/net/channel.py
+++ b/pyon/net/channel.py
@@ -292,7 +292,7 @@ class RecvChannel(BaseChannel):
             raise ChannelError("Not consuming")
 
         if self._queue_auto_delete:
-            log.info("Autodelete is on, this will destroy this queue")
+            log.debug("Autodelete is on, this will destroy this queue")
 
         blocking_cb(self._amq_chan.basic_cancel, 'callback', self._consumer_tag)
         self._consuming = False

--- a/pyon/net/test/test_endpoint.py
+++ b/pyon/net/test/test_endpoint.py
@@ -9,13 +9,13 @@ from zope.interface.interface import Interface
 from pyon.core import exception
 from pyon.net import endpoint
 from pyon.net.channel import BaseChannel, SendChannel, BidirClientChannel, SubscriberChannel, ChannelClosedError, ServerChannel
-from pyon.net.endpoint import EndpointUnit, BaseEndpoint, RPCServer, Subscriber, Publisher, RequestResponseClient, RequestEndpointUnit, RPCRequestEndpointUnit, RPCClient, _Command, RPCResponseEndpointUnit
-from gevent import event
+from pyon.net.endpoint import EndpointUnit, BaseEndpoint, RPCServer, Subscriber, Publisher, RequestResponseClient, RequestEndpointUnit, RPCRequestEndpointUnit, RPCClient, RPCResponseEndpointUnit
+from gevent import event, sleep
 from pyon.net.messaging import NodeB
 from pyon.service.service import BaseService
 from pyon.util.unit_test import PyonTestCase
 from nose.plugins.attrib import attr
-from mock import Mock
+from mock import Mock, sentinel, patch
 
 # NO INTERCEPTORS - we use these mock-like objects up top here which deliver received messages that don't go through the interceptor stack.
 endpoint.interceptors = {'message-in': [],
@@ -160,18 +160,19 @@ class RecvMockMixin(object):
     """
     Helper mixin to get a properly mocked receiving channel into several tests.
     """
-    def _setup_mock_channel(self, ch_type=BidirClientChannel, status_code=200, error_message="no problem", value="bidirmsg"):
+    def _setup_mock_channel(self, ch_type=BidirClientChannel, status_code=200, error_message="no problem", value="bidirmsg", op=None):
         """
         Sets up a mocked channel, ready for fake bidir communication.
 
         @param  ch_type         Channel type the mock should spec to.
         @param  status_code     The status code of the operation, relevant only for RR comms.
-        @param  error_messge    The error message of the operation, relevant only for RR comms.
+        @param  error_message   The error message of the operation, relevant only for RR comms.
+        @param  op              The op name, relevant only for RR comms.
         @param  value           The msg body to be returned.
         """
         ch = Mock(spec=ch_type())
         # set a return value for recv so we get an immediate response
-        vals = [(value, {'status_code':status_code, 'error_message':error_message }, 2)]
+        vals = [(value, {'status_code':status_code, 'error_message':error_message, 'op': op}, sentinel.delivery_tag)]
         def _ret(*args, **kwargs):
             if len(vals):
                 return vals.pop()
@@ -221,7 +222,7 @@ class TestSubscriber(PyonTestCase, RecvMockMixin):
         sub.listen()
 
         # make sure we got our message
-        cbmock.assert_called_once_with('subbed', {'status_code':200, 'error_message':''})
+        cbmock.assert_called_once_with('subbed', {'status_code':200, 'error_message':'', 'op': None})
 
 @attr('UNIT')
 class TestRequestResponse(PyonTestCase, RecvMockMixin):
@@ -270,8 +271,8 @@ class SimpleService(BaseService):
     dependencies = []
     def __init__(self):
         self._ar = event.AsyncResult()
-    def simple(self, *args):
-        self._ar.set(args)
+    def simple(self, named=None):
+        self._ar.set(named)
         return True
 
 @attr('UNIT')
@@ -308,7 +309,8 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
 @attr('UNIT')
 class TestRPCClient(PyonTestCase, RecvMockMixin):
 
-    def test_rpc_client(self):
+    @patch('pyon.net.endpoint.IonObject')
+    def test_rpc_client(self, iomock):
         node = Mock(spec=NodeB)
 
         rpcc = RPCClient(node=node, name="simply", iface=ISimpleInterface)
@@ -319,32 +321,71 @@ class TestRPCClient(PyonTestCase, RecvMockMixin):
         self.assertTrue(hasattr(rpcc, 'simple'))
 
         ret = rpcc.simple("zap", "zip")
+
+        iomock.assert_called_once_with('SimpleInterface_simple_in', one='zap', two='zip')
         self.assertEquals(ret, "bidirmsg")
 
 @attr('UNIT')
 class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
 
-    def simple(self, *args):
+    def simple(self, named=None):
         """
         The endpoint will fire its received message into here.
         """
-        self._ar.set(args)
+        self._ar.set(named)
 
     def test_endpoint_receive(self):
         self._ar = event.AsyncResult()
 
         # build a command object to be returned by the mocked channel
-        c = _Command(None, 'simple', None, None)
-        cvalue = c._command_dict_from_call('ein', 'zwei')
+        class FakeMsg(object):
+            def __init__(self):
+                self.named = ["ein", "zwei"]
+        cvalue = FakeMsg()
 
         e = RPCResponseEndpointUnit(routing_obj=self)
-        ch = self._setup_mock_channel(value=cvalue)
+        ch = self._setup_mock_channel(value=cvalue, op="simple")
         e.attach_channel(ch)
 
         e.spawn_listener()
         args = self._ar.get()
 
-        self.assertEquals(args, ("ein", "zwei"))
+        self.assertEquals(args, ["ein", "zwei"])
+
+    def test_receive_bad_op(self):
+
+        class FakeMsg(object):
+            def __init__(self):
+                self.named = ["ein", "zwei"]
+        cvalue = FakeMsg()
+
+        e = RPCResponseEndpointUnit(routing_obj=self)
+        ch = self._setup_mock_channel(value=cvalue, op="no_exist")
+        e.attach_channel(ch)
+
+        e.spawn_listener()
+        e._recv_greenlet.join()
+
+        # test to make sure send got called with our error
+        ch.send.assert_called_once_with(None, {'status_code':400, 'error_message':'Unknown op name: no_exist'})
+
+    def test_recv_bad_kwarg(self):
+        # we try to call simple with the kwarg "not_named" instead of the correct one
+        class FakeMsg(object):
+            def __init__(self):
+                self.not_named = ["ein", "zwei"]
+        cvalue = FakeMsg()
+
+        e = RPCResponseEndpointUnit(routing_obj=self)
+        ch = self._setup_mock_channel(value=cvalue, op="simple")
+        e.attach_channel(ch)
+
+        e.spawn_listener()
+        e._recv_greenlet.join()
+
+        # test to make sure send got called with our error
+        ch.send.assert_called_once_with(None, {'status_code':500, 'error_message':'simple() got an unexpected keyword argument \'not_named\''})
+
 
 @attr('UNIT')
 class TestRPCServer(PyonTestCase, RecvMockMixin):
@@ -355,21 +396,23 @@ class TestRPCServer(PyonTestCase, RecvMockMixin):
         rpcs = RPCServer(node=node, name="testrpc", service=svc)
 
         # build a command object to be returned by the mocked channel
-        c = _Command(None, 'simple', None, None)
-        cvalue = c._command_dict_from_call('ein', 'zwei')
+        class FakeMsg(object):
+            def __init__(self):
+                self.named = ["ein", "zwei"]
+        cvalue = FakeMsg()
 
         listen_channel_mock = self._setup_mock_channel(ch_type=ServerChannel)
         rpcs._create_main_channel = lambda: listen_channel_mock
 
         # tell our channel to return a mocked handler channel when accepted (listen() implementation detail)
-        listen_channel_mock.accept.return_value = self._setup_mock_channel(ch_type=ServerChannel.BidirAcceptChannel, value=cvalue)
+        listen_channel_mock.accept.return_value = self._setup_mock_channel(ch_type=ServerChannel.BidirAcceptChannel, value=cvalue, op="simple")
 
         rpcs.listen()
 
         # wait for first message to get passed in
         ret = svc._ar.get()
-        self.assertTrue(isinstance(ret, tuple))
-        self.assertEquals(ret, ("ein", "zwei"))
+        self.assertIsInstance(ret, list)
+        self.assertEquals(ret, ["ein", "zwei"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
TBR @mmeisinger

HUGE PROVISIONS:
- Container must add to obj_registry on startup to make sure it has IContainerAgent related *_in messages (pycc and control_cc require this)
- object loading in pyon/core/object MUST have the OrderedDict yaml patch (so we can map args to kwargs in calls)
- RPCClient reworked to better support dynamically defined interfaces, IonObject based routing, old routing removed
- generate_interfaces support for new rpc style calls, always --force now (we keep changing it too much)
