### PR TITLE
methods to give some visibility into the state machine, plus working tests

### DIFF
--- a/pyon/ion/resource.py
+++ b/pyon/ion/resource.py
@@ -167,6 +167,29 @@ class ResourceLifeCycleSM(object):
         """
         return self.transitions.get((current_state, transition_event), None)
 
+    def get_successors(self, some_state):
+        """ 
+        For a given state, return a dict of possible transition events => successor states
+        """
+        ret = {}
+        for (a_state, a_transition), a_newstate in self.transitions.iteritems():
+            if a_state == some_state:
+                #keyed on transition because they are unique with respect to origin state
+                ret[a_transition] = a_newstate
+
+        return ret
+
+    def get_predecessors(self, some_state):
+        """
+        For a given state, return a dict of possible predecessor states => the transition to move
+        """
+        ret = {}
+        for (a_state, a_transition), a_newstate in self.transitions.iteritems():
+            if a_newstate == some_state:
+                #keyed on state because they are unique with respect to destination state
+                ret[a_state] = a_transition
+
+        return ret
 
 class InformationResourceLCSM(ResourceLifeCycleSM):
     ILLEGAL_STATES = []

--- a/pyon/ion/test/test_resource.py
+++ b/pyon/ion/test/test_resource.py
@@ -37,3 +37,8 @@ class TestResources(PyonTestCase):
 
         self.assertEquals(default_workflow.get_successor(LCS.PLANNED, ResourceLifeCycleSM.DEVELOP), LCS.DEVELOPED)
         self.assertEquals(default_workflow.get_successor(LCS.DEVELOPED, ResourceLifeCycleSM.RETIRE), LCS.RETIRED)
+
+        self.assertEquals(default_workflow.get_successors(LCS.PLANNED), {ResourceLifeCycleSM.DEPLOY: LCS.PRIVATE,
+                                                                         ResourceLifeCycleSM.DEVELOP: LCS.DEVELOPED,
+                                                                         ResourceLifeCycleSM.RETIRE: LCS.RETIRED})
+        self.assertEquals(default_workflow.get_predecessors(LCS.DEVELOPED), {LCS.PLANNED: ResourceLifeCycleSM.DEVELOP})


### PR DESCRIPTION
I've added 2 methods to the state machine: get_successors and get_predecessors.  Since some states can be reached by more than one transition (for example: private, by deploying or hiding), these functions will help ensure the proper checks are done at the proper times.
