### PR TITLE
Numpy interceptor codec

### DIFF
--- a/pyon/core/interceptor/codec.py
+++ b/pyon/core/interceptor/codec.py
@@ -27,11 +27,7 @@ class CodecInterceptor(Interceptor):
         if _have_numpy:
             if isinstance(invocation.message,np.ndarray):
                 serializer = NumpyObjectSerialization()
-                np_object = invocation.message
-                invocation.message = {'numpy': {
-                    'type':str(np_object.dtype),
-                    'shape':np_object.shape,
-                    'body':serializer.transform(np_object)}}
+                invocation.message = serializer.transform(invocation.message)
                 log.debug('Numpy:\n  Message: %s', invocation.message)
 
 

--- a/pyon/core/interceptor/codec.py
+++ b/pyon/core/interceptor/codec.py
@@ -2,13 +2,21 @@ from pyon.core.interceptor.interceptor import Interceptor
 from pyon.core.bootstrap import obj_registry
 from pyon.core.object import IonObjectDeserializer, IonObjectSerializer, walk
 from pyon.util.log import log
+try:
+    import numpy as np
+    _have_numpy = True
+except ImportError as e:
+    _have_numpy = False
 
+if _have_numpy:
+    from pyon.core.object import NumpyObjectDeserialization, NumpyObjectSerialization
 class CodecInterceptor(Interceptor):
     """
     Transforms IonObject <-> dict
     """
     def __init__(self):
         Interceptor.__init__(self)
+
         self._io_serializer = IonObjectSerializer()
         self._io_deserializer = IonObjectDeserializer(obj_registry=obj_registry)
 
@@ -16,6 +24,17 @@ class CodecInterceptor(Interceptor):
         log.debug("CodecInterceptor.outgoing: %s", invocation)
 
         log.debug("Payload, pre-transform: %s", invocation.message)
+        if _have_numpy:
+            if isinstance(invocation.message,np.ndarray):
+                serializer = NumpyObjectSerialization()
+                np_object = invocation.message
+                invocation.message = {'numpy': {
+                    'type':str(np_object.dtype),
+                    'shape':np_object.shape,
+                    'body':serializer.transform(np_object)}}
+                log.debug('Numpy:\n  Message: %s', invocation.message)
+
+
         invocation.message = self._io_serializer.serialize(invocation.message)
         log.debug("Payload, post-transform: %s", invocation.message)
 
@@ -25,7 +44,19 @@ class CodecInterceptor(Interceptor):
         log.debug("CodecInterceptor.incoming: %s", invocation)
 
         payload = invocation.message
+
         log.debug("Payload, pre-transform: %s", payload)
+
+        if _have_numpy:
+            if isinstance(invocation.message,dict):
+                msg = invocation.message.get('numpy',False)
+                if msg:
+                    deserializer = NumpyObjectDeserialization()
+                    invocation.message = deserializer.transform(msg)
+                    log.debug("Payload, post-transform: %s", invocation.message)
+                    return invocation
+
+
 
         # Horrible, hacky workaround for msgpack issue
         # See http://jira.msgpack.org/browse/MSGPACK-15

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -139,7 +139,7 @@ if _have_numpy:
                     'shape':obj.shape,
                     'body':obj.tostring()
                 }}
-                
+
                 return msg
             return obj
 

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -134,7 +134,12 @@ if _have_numpy:
         '''
         def transform(self, obj):
             if isinstance(obj,np.ndarray):
-                msg = obj.tostring()
+                msg = {'numpy': {
+                    'type':str(obj.dtype),
+                    'shape':obj.shape,
+                    'body':obj.tostring()
+                }}
+                
                 return msg
             return obj
 

--- a/pyon/net/test/test_messaging.py
+++ b/pyon/net/test/test_messaging.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from pyon.core.interceptor.codec import CodecInterceptor
+from pyon.core.interceptor.interceptor import Invocation
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
@@ -14,6 +16,12 @@ from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.async import spawn
 from gevent import event, queue
 import time
+
+try:
+    import numpy as np
+    _have_numpy = True
+except ImportError as e:
+    _have_numpy = False
 
 @attr('UNIT')
 class TestNodeB(PyonTestCase):
@@ -227,6 +235,22 @@ class TestMessaging(PyonTestCase):
 
         self.assertEquals(ilp, sentinel.ioloop_process)
         gevmock.assert_called_once_with(ioloop, sentinel.connection)
+
+    def test_numpy_codec(self):
+        if not _have_numpy:
+            return
+        a = np.array([(90,8010,3,14112,3.14159265358979323846264)],dtype='float32')
+        invoke = Invocation()
+        invoke.message = a
+        codec = CodecInterceptor()
+
+        mangled = codec.outgoing(invoke)
+
+        received = codec.incoming(mangled)
+
+        b = received.message
+        comp = (a==b)
+        self.assertTrue(comp.all())
 
 
 


### PR DESCRIPTION
A numpy codec was added to the interceptor stack to support sending and receiving numpy arrays. The data translation has been confirmed as lossless at various precisions (including float32). If the recipient does not have numpy it is simply a dictionary packed with strings, so it will not break a client receiving a numpy object.
