### PR TITLE
Numpy Interceptor

### DIFF
--- a/pyon/core/interceptor/test/__init__.py
+++ b/pyon/core/interceptor/test/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'luke'

--- a/pyon/core/interceptor/test/interceptor_test.py
+++ b/pyon/core/interceptor/test/interceptor_test.py
@@ -1,0 +1,51 @@
+'''
+@author Luke Campbell <lcampbell@asascience.com>
+@file pyon/core/interceptor/test/interceptor_test.py
+@description test lib for interceptor
+'''
+import unittest
+from pyon.core.interceptor.codec import CodecInterceptor
+from pyon.core.interceptor.interceptor import Invocation
+from pyon.util import log
+from pyon.util.unit_test import PyonTestCase
+from nose.plugins.attrib import attr
+
+try:
+    import numpy as np
+    _have_numpy = True
+except ImportError as e:
+    _have_numpy = False
+
+@attr('UNIT')
+class InterceptorTest(PyonTestCase):
+    @unittest.skipIf(not _have_numpy,'No numpy')
+    def test_numpy_codec(self):
+
+        a = np.array([(90,8010,3,14112,3.14159265358979323846264)],dtype='float32')
+        invoke = Invocation()
+        invoke.message = a
+        codec = CodecInterceptor()
+
+        mangled = codec.outgoing(invoke)
+
+        received = codec.incoming(mangled)
+
+        b = received.message
+        comp = (a==b)
+        self.assertTrue(comp.all())
+    @unittest.skipIf(not _have_numpy,'No numpy')
+    def test_packed_numpy(self):
+        a = np.array([(90,8010,3,14112,3.14159265358979323846264)],dtype='float32')
+        invoke = Invocation()
+        invoke.message = {'double stuffed':[a,a,a]}
+        codec = CodecInterceptor()
+
+        mangled = codec.outgoing(invoke)
+
+        received = codec.incoming(mangled)
+
+        b = received.message
+        c = b.get('double stuffed')
+        for d in c:
+            e = (a==d)
+            self.assertTrue(e.all())

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -8,7 +8,11 @@ from collections import OrderedDict, Mapping, Iterable
 import yaml
 
 from pyon.util.log import log
-
+try:
+    import numpy as np
+    _have_numpy = True
+except ImportError as e:
+    _have_numpy = False
 
 class IonObjectBase(object):
 
@@ -104,11 +108,15 @@ def walk(o, cb):
     newo = cb(o)
 
     # is now or is still an iterable? iterate it.
+    if _have_numpy:
+        if isinstance(newo,np.ndarray):
+            return newo
     if hasattr(newo, '__iter__'):
         if isinstance(newo, dict):
             return dict(((k, walk(v, cb)) for k,v in newo.iteritems()))
         else:
             return [walk(x, cb) for x in newo]
+
     elif isinstance(newo, IonObjectBase):
         # IOs are not iterable and are a huge pain to make them look iterable, special casing is fine then
         # @TODO consolidate with _validate method in IonObjectBase
@@ -124,6 +132,10 @@ def walk(o, cb):
 
     else:
         return newo
+
+
+
+
 
 
 class IonObjectSerializationBase(object):
@@ -144,6 +156,8 @@ class IonObjectSerializationBase(object):
 
     def _transform(self, obj):
         raise NotImplementedError("Implement _transform in a derived class")
+
+
     
 class IonObjectSerializer(IonObjectSerializationBase):
     """
@@ -162,6 +176,16 @@ class IonObjectSerializer(IonObjectSerializationBase):
             res = obj.__dict__
             res["type_"] = obj.__class__.__name__
             return res
+        if _have_numpy:
+            if isinstance(obj,np.ndarray):
+                log.debug('got numpy: %s', type(obj))
+                res = {'numpy': {
+                    'type':str(obj.dtype),
+                    'shape':obj.shape,
+                    'body':obj.tostring()
+                }}
+                log.debug('res: %s', res)
+                return res
 
         return obj
 
@@ -193,6 +217,18 @@ class IonObjectDeserializer(IonObjectSerializationBase):
                 setattr(ion_obj, k, v)
 
             return ion_obj
+        if _have_numpy:
+            if isinstance(obj, dict):
+                msg = obj.get('numpy',False)
+                log.debug('message = %s', msg)
+                if msg:
+                    shape = msg.get('shape')
+                    type = msg.get('type')
+                    data = msg.get('body')
+                    log.debug('Numpy Array Detected:\n  type: %s\n  shape: %s\n  body: %s',type,shape,data)
+                    ret = np.fromstring(string=data,dtype=type).reshape(shape)
+                    return np.array(ret)
+
 
         return obj
 


### PR DESCRIPTION
A numpy codec was added to the interceptor stack to support sending and
receiving numpy arrays. The data translation has been confirmed as
lossless at various precisions (including float32). If the recipient
does not have numpy it is simply a dictionary packed with strings, so it
will not break a client receiving a numpy object.
