### PR TITLE
Fail fast support in container

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -4,7 +4,7 @@
 Capability Container base class
 """
 
-__author__ = 'Adam R. Smith, Michael Meisinger'
+__author__ = 'Adam R. Smith, Michael Meisinger, Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
 
 from pyon.core.bootstrap import CFG, bootstrap_pyon
@@ -198,3 +198,10 @@ class Container(BaseContainerAgent):
         log.debug("Container stopped, OK.")
 
         Container.instance = None
+
+    def fail_fast(self, err_msg=""):
+        """
+        Container needs to shut down and NOW.
+        """
+        log.error("Fail Fast: %s", err_msg)
+        os.kill(os.getpid(), signal.SIGTERM)

--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -204,4 +204,6 @@ class Container(BaseContainerAgent):
         Container needs to shut down and NOW.
         """
         log.error("Fail Fast: %s", err_msg)
+        self.stop()
+        log.error("Fail Fast: killing container")
         os.kill(os.getpid(), signal.SIGTERM)

--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -120,8 +120,9 @@ class Container(BaseContainerAgent):
         rsvc = ProcessRPCServer(node=self.node, name=self.name, service=self, process=self)
 
         # Start an ION process with the right kind of endpoint factory
-        self.proc_manager.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=rsvc)
-        rsvc.get_ready_event().wait(timeout=10)   # @TODO: no hardcode
+        proc = self.proc_manager.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=rsvc)
+        self.proc_manager.proc_sup.ensure_ready(proc)
+
         log.info("Container started, OK.")
 
     def serve_forever(self):

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -129,9 +129,7 @@ class ProcManager(object):
             log.warn("svc %s not found in procs list", svc)
             return
 
-        # if this the only proc, fail, and hard
-        if len(self.procs) == 1:
-            self.container.fail_fast("Container's only process (%s) failed: %s" % (svc, gproc.exception))
+        self.container.fail_fast("Container's only process (%s) failed: %s" % (svc, gproc.exception))
 
     def _spawn_service_process(self, process_id, name, module, cls, config):
         """

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -117,19 +117,22 @@ class ProcManager(object):
     def _spawned_proc_failed(self, proc_sup, gproc):
         log.error("ProcManager._spawned_proc_failed: %s", gproc)
 
-        # look it up in mapping
-        if not gproc in self._spawned_proc_to_process:
-            log.warn("No record of gproc %s in our map (%s)", gproc, self._spawned_proc_to_process)
-            return
+        # for now - don't worry about the mapping, if we get a failure, just kill the container.
+        # leave the mapping in place for potential expansion later.
 
-        svc = self._spawned_proc_to_process[gproc]
+#        # look it up in mapping
+#        if not gproc in self._spawned_proc_to_process:
+#            log.warn("No record of gproc %s in our map (%s)", gproc, self._spawned_proc_to_process)
+#            return
+#
+        svc = self._spawned_proc_to_process.get(gproc, "Unknown")
+#
+#        # make sure svc is in our list
+#        if not svc in self.procs.values():
+#            log.warn("svc %s not found in procs list", svc)
+#            return
 
-        # make sure svc is in our list
-        if not svc in self.procs.values():
-            log.warn("svc %s not found in procs list", svc)
-            return
-
-        self.container.fail_fast("Container's only process (%s) failed: %s" % (svc, gproc.exception))
+        self.container.fail_fast("Container process (%s) failed: %s" % (svc, gproc.exception))
 
     def _spawn_service_process(self, process_id, name, module, cls, config):
         """

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -228,9 +228,8 @@ class ProcManager(object):
                                 service=service_instance,
                                 process=service_instance)
         # Start an ION process with the right kind of endpoint factory
-        self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=rsvc, name=listen_name)
-        if not rsvc.get_ready_event().wait(timeout=10):
-            raise exception.ContainerError('_set_service_endpoint for listen_name: %s did not report ok' % listen_name)
+        proc = self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=rsvc, name=listen_name)
+        self.proc_sup.ensure_ready(proc, "_set_service_endpoint for listen_name: %s" % listen_name)
 
         log.debug("Process %s service listener ready: %s", service_instance.id, listen_name)
 
@@ -241,9 +240,8 @@ class ProcManager(object):
 
         sub = service_instance.stream_subscriber_registrar.create_subscriber(exchange_name=listen_name,callback=lambda m,h: service_instance.process(m))
 
-        self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=sub, name=listen_name)
-        if not sub.get_ready_event().wait(timeout=10):
-            raise exception.ContainerError('_set_subscription_endpoint for listen_name: %s did not report ok' % listen_name)
+        proc = self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=sub, name=listen_name)
+        self.proc_sup.ensure_ready(proc, '_set_subscription_endpoint for listen_name: %s' % listen_name)
 
         log.debug("Process %s stream listener ready: %s", service_instance.id, listen_name)
 

--- a/pyon/container/test/test_cc.py
+++ b/pyon/container/test/test_cc.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+__author__ = 'Dave Foster <dfoster@asascience.com>'
+
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.util.unit_test import PyonTestCase
+from nose.plugins.attrib import attr
+from pyon.container.cc import Container
+import signal
+from gevent.event import Event
+from mock import Mock, patch
+
+@attr('UNIT')
+class TestCC(PyonTestCase):
+    def setUp(self):
+        self.cc = Container()
+
+    @patch('pyon.container.cc.log')
+    @patch('pyon.container.cc.os')
+    def test_fail_fast(self, osmock, logmock):
+        self.cc.stop = Mock()
+
+        self.cc.fail_fast('dippin dots')
+
+        # make sure it called the things we expect
+        self.assertIn('dippin dots', str(logmock.error.call_args_list[0]))
+        self.cc.stop.assert_called_once_with()
+        osmock.kill.assert_called_once_with(osmock.getpid(), signal.SIGTERM)
+
+@attr('INT')
+class TestCCInt(IonIntegrationTestCase):
+
+    def setUp(self):
+        # we don't want to connect to AMQP or do a pidfile or any of that jazz - just the proc manager please
+        self.cc = Container()
+        self.cc.proc_manager.start()
+        self.cc.stop = Mock()
+        self.cc.stop.side_effect = self.cc.proc_manager.stop()
+
+    def tearDown(self):
+        pass
+
+    def test_fail_fast(self):
+
+        # need to install signal protection so we don't kill nosetests!
+        ev = Event()
+        def no_abort(*args):
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            ev.set()
+
+        signal.signal(signal.SIGTERM, no_abort)
+
+        # spawn the proc, wait for it to die and kill the container
+        def failtarget(*args, **kwargs):
+            raise StandardError("I am supposed to fail!")
+
+        self.cc.proc_manager.proc_sup.spawn(('green', failtarget))
+
+        # wait for the kill signal to happen
+        ev.wait(timeout=5)
+
+        # verify things got called
+        self.cc.stop.assert_called_once_with()
+

--- a/pyon/core/exception.py
+++ b/pyon/core/exception.py
@@ -14,9 +14,6 @@ SERVICE_UNAVAILABLE = 503
 class IonException(Exception):
     status_code = -1
 
-    def __init__(self, message=''):
-        self.message = message
-
     def get_status_code(self):
         return self.status_code
 

--- a/pyon/core/process.py
+++ b/pyon/core/process.py
@@ -86,7 +86,7 @@ class PyonProcess(object):
         self.proc = None
 
         if self.supervisor is not None:
-                self.supervisor.child_stopped(self)
+            self.supervisor.child_stopped(self)
 
         return self
 
@@ -257,14 +257,17 @@ class ProcessSupervisor(object):
 
         # unlink the events: ready event is probably harmless but the exception one, we want to install our own later
         proc.get_ready_event().unlink(cb)
-        proc.proc.unlink(cb)
+
+        # if the process is stopped while we are waiting, proc.proc is set to None
+        if proc.proc is not None:
+            proc.proc.unlink(cb)
 
         # raise an exception if:
         # - we timed out
         # - we caught an exception
         if not retval:
             raise ContainerError("%s (timed out)" % errmsg)
-        elif proc.proc.dead and not proc.proc.successful():
+        elif proc.proc is not None and proc.proc.dead and not proc.proc.successful():
             raise ContainerError("%s (failed): %s" % (errmsg, proc.proc.exception))
 
     def child_stopped(self, proc):

--- a/pyon/core/process.py
+++ b/pyon/core/process.py
@@ -193,7 +193,7 @@ class ProcessSupervisor(object):
             proc_type, proc_target = type_and_target
             proc_callable = self.type_callables[proc_type]
             proc = proc_callable(proc_target, *args, **kwargs)
-        elif isinstance(type_and_target, PyonProcess) and hasattr(type_and_target, 'target'):
+        elif issubclass(type_and_target, PyonProcess) and hasattr(type_and_target, 'target'):
             proc = type_and_target(*args, **kwargs)
         else:
             raise PyonProcessError('Invalid proc_type (must be tuple or PyonProcess subclass with a target method)')
@@ -204,7 +204,7 @@ class ProcessSupervisor(object):
         self.children.add(proc)
         return proc
 
-    def ensure_ready(self, proc, errmsg=None):
+    def ensure_ready(self, proc, errmsg=None, timeout=10):
         """
         Waits until either the process dies or reports it is ready, whichever comes first.
 
@@ -214,6 +214,7 @@ class ProcessSupervisor(object):
 
         @param  proc        The process to wait on.
         @param  errmsg      A custom error message to put in the ContainerError's message. May be blank.
+        @param  timeout     Amount of time (in seconds) to wait for the ready, default 10 seconds.
         @throws ContainerError  If the process dies or if we get a timeout before the process signals ready.
         """
 
@@ -233,7 +234,7 @@ class ProcessSupervisor(object):
         proc.proc.link_exception(cb)
         proc.get_ready_event().rawlink(cb)
 
-        retval = ev.wait(timeout=10)
+        retval = ev.wait(timeout=timeout)
 
         # unlink the events: ready event is probably harmless but the exception one, we want to install our own later
         proc.get_ready_event().unlink(cb)

--- a/pyon/core/process.py
+++ b/pyon/core/process.py
@@ -275,7 +275,8 @@ class ProcessSupervisor(object):
             self.children.remove(proc)
 
             # no longer need to listen for exceptions
-            proc.proc.unlink(self._child_failed)
+            if proc.proc is not None:
+                proc.proc.unlink(self._child_failed)
 
     def join_children(self, timeout=None):
         """ Give child processes "timeout" seconds to shutdown, then forcibly terminate. """

--- a/pyon/ion/process.py
+++ b/pyon/ion/process.py
@@ -14,13 +14,15 @@ class IonProcessBase(object):
     Form the base of an ION process.
     Just add greenlets or python processes to complete.
     """
-    
-    def target(self, listener=None, name=None, *args, **kwargs):
+
+    def __init__(self, listener=None, name=None):
+        self.listener   = listener
+        self.name       = name
+
+    def target(self, *args, **kwargs):
         """ Control entrypoint. Setup the base properties for this process (mainly a listener)."""
-        self.listener = listener
-        self.name = name
-        if name:
-            threading.current_thread().name = name
+        if self.name:
+            threading.current_thread().name = self.name
         self.listener.listen()
 
     def _notify_stop(self):
@@ -28,7 +30,14 @@ class IonProcessBase(object):
         super(IonProcessBase, self)._notify_stop()
 
 class GreenIonProcess(IonProcessBase, GreenProcess):
-    pass
+
+    def __init__(self, target=None, listener=None, name=None, *args, **kwargs):
+        IonProcessBase.__init__(self, listener=listener, name=name)
+        GreenProcess.__init__(self, target=target, *args, **kwargs)
+
+    def get_ready_event(self):
+        return self.listener.get_ready_event()
+
 class PythonIonProcess(IonProcessBase, PythonProcess):
     pass
 


### PR DESCRIPTION
Changes to support the container's fail fast, also touches/cleans up process manager stuff.

TBR @mmeisinger
- ensure_ready: instead of waiting for RPCServer specific ready event, make the ready event generic to any spawned process, will also trap errors on startup resulting in greenlet deaths and raise an exception in the waiting greenlet.  Cleans up startup logic.
- Monitor for failed greenlets/procs spawned by proc manager/proc supervisor.
- GreenIonProcess now has an initializer instead of setting instance vars in the target method
- Channel layer now uses custom synchronous wrapper instead of generic blocking_cb, can handle errors
