### PR TITLE
Fixed issues in Directory and Datastore

### DIFF
--- a/pyon/datastore/datastore.py
+++ b/pyon/datastore/datastore.py
@@ -434,7 +434,7 @@ class DatastoreManager(object):
             new_ds = CouchDB_DataStore(datastore_name=scoped_name, profile=profile)
         else:
             from pyon.datastore.mockdb.mockdb_datastore import MockDB_DataStore
-            new_ds = MockDB_DataStore(datastore_name=scoped_name, profile=profile)
+            new_ds = MockDB_DataStore(datastore_name=scoped_name) #, profile=profile)
 
         # Clean the store instance
         if force_clean:

--- a/pyon/ion/directory.py
+++ b/pyon/ion/directory.py
@@ -23,10 +23,15 @@ class Directory(object):
         """
         Create singleton instance
         """
+        if Directory.__instance == "NEW":
+            log.warn("Somehow __instance is 'NEW' outside of get_instance() singleton code")
+            Directory.__instance = None
+
         if Directory.__instance is None:
             Directory.__instance = "NEW"
             # Create and remember instance
             Directory.__instance = Directory()
+            assert Directory.__instance != "NEW", "Directory was not instantiated"
         return Directory.__instance
 
     def __init__(self):


### PR DESCRIPTION
Datastore: incorrect init argument being supplied to mockdb, removed

Directory: if __instance falls into the state "NEW", you're screwed.  Caught and fixed, with a warning.
