### PR TITLE
Remove singletons from DatastoreManager and related classes

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -123,7 +123,7 @@ class Container(BaseContainerAgent):
         self.app_manager.start()
 
         # Create other repositories
-        self.state_repository = StateRepository.get_instance(self.datastore_manager)
+        self.state_repository = StateRepository(self.datastore_manager)
         self.event_repository = EventRepository.get_instance(self.datastore_manager)
 
         # Start the CC-Agent API

--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -113,9 +113,9 @@ class Container(BaseContainerAgent):
         self.node, self.ioloop = messaging.make_node() # TODO: shortcut hack
 
 
-        # Instantiate Directory singleton and self-register
+        # Instantiate Directory and self-register
         # TODO: At this point, there is no special config override
-        self.directory = Directory.get_instance(self.datastore_manager)
+        self.directory = Directory(self.datastore_manager)
         self.directory.register("/Containers", self.id, cc_agent=self.name)
 
         self.proc_manager.start()

--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -124,7 +124,7 @@ class Container(BaseContainerAgent):
 
         # Create other repositories
         self.state_repository = StateRepository(self.datastore_manager)
-        self.event_repository = EventRepository.get_instance(self.datastore_manager)
+        self.event_repository = EventRepository(self.datastore_manager)
 
         # Start the CC-Agent API
         rsvc = ProcessRPCServer(node=self.node, name=self.name, service=self, process=self)

--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -20,6 +20,7 @@ from pyon.util.log import log
 from pyon.util.containers import DictModifier, dict_merge
 from pyon.ion.exchange import ExchangeManager
 from interface.services.icontainer_agent import BaseContainerAgent
+from pyon.datastore.datastore import DatastoreManager
 
 import atexit
 import msgpack
@@ -70,6 +71,9 @@ class Container(BaseContainerAgent):
 
         # Create this Container's specific AppManager instance
         self.app_manager = AppManager(self)
+
+        # DatastoreManager - controls access to Datastores (both mock and couch backed)
+        self.datastore_manager = DatastoreManager()
         
         log.debug("Container initialized, OK.")
 
@@ -111,7 +115,7 @@ class Container(BaseContainerAgent):
 
         # Instantiate Directory singleton and self-register
         # TODO: At this point, there is no special config override
-        self.directory = Directory.get_instance()
+        self.directory = Directory.get_instance(self.datastore_manager)
         self.directory.register("/Containers", self.id, cc_agent=self.name)
 
         self.proc_manager.start()
@@ -119,8 +123,8 @@ class Container(BaseContainerAgent):
         self.app_manager.start()
 
         # Create other repositories
-        self.state_repository = StateRepository.get_instance()
-        self.event_repository = EventRepository.get_instance()
+        self.state_repository = StateRepository.get_instance(self.datastore_manager)
+        self.event_repository = EventRepository.get_instance(self.datastore_manager)
 
         # Start the CC-Agent API
         rsvc = ProcessRPCServer(node=self.node, name=self.name, service=self, process=self)
@@ -199,6 +203,12 @@ class Container(BaseContainerAgent):
             self.state_repository.close()
         except Exception, ex:
             log.exception("Container stop(): Error closing state repository")
+
+        try:
+            # close any open connections to datastores
+            self.datastore_manager.close()
+        except Exception, ex:
+            log.exception("Container stop(): Error closing datastore_manager")
 
         try:
             self.node.client.close()

--- a/pyon/container/shell_api.py
+++ b/pyon/container/shell_api.py
@@ -201,7 +201,7 @@ def lsdir(qname='/', truncate=True):
     @param qname the directory node (must start with '/')
     """
     from pyon.ion.directory import Directory
-    ds = Directory.get_instance()
+    ds = Directory.get_instance(container.datastore_manager)
     delist = ds.find_entries(qname)
     detable = [(str(de._id), str(de.attributes)) for de in delist]
 

--- a/pyon/container/shell_api.py
+++ b/pyon/container/shell_api.py
@@ -200,8 +200,7 @@ def lsdir(qname='/', truncate=True):
     """Prints all directory entries below the given node.
     @param qname the directory node (must start with '/')
     """
-    from pyon.ion.directory import Directory
-    ds = Directory.get_instance(container.datastore_manager)
+    ds = container.directory
     delist = ds.find_entries(qname)
     detable = [(str(de._id), str(de.attributes)) for de in delist]
 

--- a/pyon/datastore/datastore.py
+++ b/pyon/datastore/datastore.py
@@ -397,13 +397,13 @@ class DataStore(object):
 
 class DatastoreManager(object):
     """
-    Simple manager for datastore instances. Static use.
+    Simple manager for datastore instances.
     """
 
-    datastores = {}
+    def __init__(self):
+        self._datastores = {}
 
-    @classmethod
-    def get_datastore(cls, ds_name, profile=DataStore.DS_PROFILE.BASIC, config=None):
+    def get_datastore(self, ds_name, profile=DataStore.DS_PROFILE.BASIC, config=None):
         """
         Factory method to get a datastore instance from given name, profile and config.
         This is the central point to cache these instances, to decide persistent or mock
@@ -411,9 +411,9 @@ class DatastoreManager(object):
         @param profile  One of known constants determining the use of the store
         """
         assert ds_name, "Must provide ds_name"
-        if ds_name in DatastoreManager.datastores:
+        if ds_name in self._datastores:
             log.debug("get_datastore(): Found instance of store '%s'" % ds_name)
-            return DatastoreManager.datastores[ds_name]
+            return self._datastores[ds_name]
 
         scoped_name = ("%s_%s" % (sys_name, ds_name)).lower()
 
@@ -451,6 +451,13 @@ class DatastoreManager(object):
         new_ds.local_name = ds_name
         new_ds.ds_profile = profile
 
-        DatastoreManager.datastores[ds_name] = new_ds
+        self._datastores[ds_name] = new_ds
 
         return new_ds
+
+    def close(self):
+        log.debug("DatastoreManager.close (%d datastores)", len(self._datastores))
+        for x in self._datastores.itervalues():
+            x.close()
+
+        self._datastores = {}

--- a/pyon/event/event.py
+++ b/pyon/event/event.py
@@ -38,7 +38,9 @@ class EventPublisher(Publisher):
 
         Publisher.__init__(self, name=name, **kwargs)
 
-        self.event_repo = EventRepository.get_instance()
+        # @TODO: not great at all
+        from pyon.container.cc import Container
+        self.event_repo = EventRepository.get_instance(Container.instance.datastore_manager)
 
     def _topic(self, origin):
         """
@@ -485,22 +487,22 @@ class EventRepository(object):
     __instance = None
 
     @classmethod
-    def get_instance(cls):
+    def get_instance(cls, datastore_manager):
         """
         Create singleton instance
         """
         if EventRepository.__instance is None:
             EventRepository.__instance = "NEW"
             # Create and remember instance
-            EventRepository.__instance = EventRepository()
+            EventRepository.__instance = EventRepository(datastore_manager)
         return EventRepository.__instance
 
-    def __init__(self):
+    def __init__(self, datastore_manager):
         assert EventRepository.__instance == "NEW", "Cannot instantiate EventRepository multiple times"
 
         # Get an instance of datastore configured as directory.
         # May be persistent or mock, forced clean, with indexes
-        self.event_store = DatastoreManager.get_datastore("events", DataStore.DS_PROFILE.EVENTS)
+        self.event_store = datastore_manager.get_datastore("events", DataStore.DS_PROFILE.EVENTS)
 
     def close(self):
         """

--- a/pyon/event/test/test_event.py
+++ b/pyon/event/test/test_event.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pyon.datastore.datastore import DatastoreManager
 
 __author__ = 'Dave Foster <dfoster@asascience.com>, Michael Meisinger'
 __license__ = 'Apache 2.0'
@@ -320,8 +321,10 @@ class TestEventRepository(IonUnitTestCase):
         if bootstrap.CFG.system.mockdb:
             raise SkipTest("only works with CouchDB views")
 
-        event_repo = EventRepository.get_instance()
-        event_repo1 = EventRepository.get_instance()
+        dsm = DatastoreManager()
+
+        event_repo = EventRepository.get_instance(dsm)
+        event_repo1 = EventRepository.get_instance(dsm)
         self.assertEquals(event_repo, event_repo1)
 
         event1 = Event(origin="resource1")

--- a/pyon/ion/directory.py
+++ b/pyon/ion/directory.py
@@ -12,31 +12,10 @@ from pyon.util.log import log
 
 class Directory(object):
     """
-    Singleton class that uses a data store to provide a directory lookup mechanism.
+    Class that uses a data store to provide a directory lookup mechanism.
     """
 
-    # Storage for the instance reference
-    __instance = None
-
-    @classmethod
-    def get_instance(cls, datastore_manager):
-        """
-        Create singleton instance
-        """
-        if Directory.__instance == "NEW":
-            log.warn("Somehow __instance is 'NEW' outside of get_instance() singleton code")
-            Directory.__instance = None
-
-        if Directory.__instance is None:
-            Directory.__instance = "NEW"
-            # Create and remember instance
-            Directory.__instance = Directory(datastore_manager)
-            assert Directory.__instance != "NEW", "Directory was not instantiated"
-        return Directory.__instance
-
     def __init__(self, datastore_manager):
-        assert Directory.__instance == "NEW", "Cannot instantiate Directory multiple times"
-
         # Get an instance of datastore configured as directory.
         # May be persistent or mock, forced clean, with indexes
         self.dir_store = datastore_manager.get_datastore("directory", DataStore.DS_PROFILE.DIRECTORY)

--- a/pyon/ion/directory.py
+++ b/pyon/ion/directory.py
@@ -19,7 +19,7 @@ class Directory(object):
     __instance = None
 
     @classmethod
-    def get_instance(cls):
+    def get_instance(cls, datastore_manager):
         """
         Create singleton instance
         """
@@ -30,16 +30,16 @@ class Directory(object):
         if Directory.__instance is None:
             Directory.__instance = "NEW"
             # Create and remember instance
-            Directory.__instance = Directory()
+            Directory.__instance = Directory(datastore_manager)
             assert Directory.__instance != "NEW", "Directory was not instantiated"
         return Directory.__instance
 
-    def __init__(self):
+    def __init__(self, datastore_manager):
         assert Directory.__instance == "NEW", "Cannot instantiate Directory multiple times"
 
         # Get an instance of datastore configured as directory.
         # May be persistent or mock, forced clean, with indexes
-        self.dir_store = DatastoreManager.get_datastore("directory", DataStore.DS_PROFILE.DIRECTORY)
+        self.dir_store = datastore_manager.get_datastore("directory", DataStore.DS_PROFILE.DIRECTORY)
 
         self._init()
 

--- a/pyon/ion/state.py
+++ b/pyon/ion/state.py
@@ -23,22 +23,22 @@ class StateRepository(object):
     __instance = None
 
     @classmethod
-    def get_instance(cls):
+    def get_instance(cls, datastore_manager):
         """
         Create singleton instance
         """
         if StateRepository.__instance is None:
             StateRepository.__instance = "NEW"
             # Create and remember instance
-            StateRepository.__instance = StateRepository()
+            StateRepository.__instance = StateRepository(datastore_manager)
         return StateRepository.__instance
 
-    def __init__(self):
+    def __init__(self, datastore_manager):
         assert StateRepository.__instance == "NEW", "Cannot instantiate StateRepository multiple times"
 
         # Get an instance of datastore configured as directory.
         # May be persistent or mock, forced clean, with indexes
-        self.state_store = DatastoreManager.get_datastore("state", DataStore.DS_PROFILE.STATE)
+        self.state_store = datastore_manager.get_datastore("state", DataStore.DS_PROFILE.STATE)
 
     def close(self):
         """

--- a/pyon/ion/state.py
+++ b/pyon/ion/state.py
@@ -16,25 +16,10 @@ from interface.objects import ProcessState
 
 class StateRepository(object):
     """
-    Singleton class that uses a data store to provide a persistent state repository for ION processes.
+    Class that uses a data store to provide a persistent state repository for ION processes.
     """
 
-    # Storage for the instance reference
-    __instance = None
-
-    @classmethod
-    def get_instance(cls, datastore_manager):
-        """
-        Create singleton instance
-        """
-        if StateRepository.__instance is None:
-            StateRepository.__instance = "NEW"
-            # Create and remember instance
-            StateRepository.__instance = StateRepository(datastore_manager)
-        return StateRepository.__instance
-
     def __init__(self, datastore_manager):
-        assert StateRepository.__instance == "NEW", "Cannot instantiate StateRepository multiple times"
 
         # Get an instance of datastore configured as directory.
         # May be persistent or mock, forced clean, with indexes

--- a/pyon/ion/test/test_directory.py
+++ b/pyon/ion/test/test_directory.py
@@ -6,13 +6,14 @@ __license__ = 'Apache 2.0'
 from pyon.ion.directory import Directory
 from pyon.util.unit_test import IonUnitTestCase
 from nose.plugins.attrib import attr
+from pyon.datastore.datastore import DatastoreManager
 
 
 @attr('UNIT',group='datastore')
 class TestDirectory(IonUnitTestCase):
 
     def test_directory(self):
-        directory_service = Directory.get_instance()
+        directory_service = Directory.get_instance(DatastoreManager())
 
         root = directory_service.lookup("/")
         self.assertEquals(root, None)

--- a/pyon/ion/test/test_directory.py
+++ b/pyon/ion/test/test_directory.py
@@ -13,7 +13,7 @@ from pyon.datastore.datastore import DatastoreManager
 class TestDirectory(IonUnitTestCase):
 
     def test_directory(self):
-        directory_service = Directory.get_instance(DatastoreManager())
+        directory_service = Directory(DatastoreManager())
 
         root = directory_service.lookup("/")
         self.assertEquals(root, None)

--- a/pyon/ion/test/test_state.py
+++ b/pyon/ion/test/test_state.py
@@ -7,14 +7,16 @@ from pyon.ion.state import StateRepository
 from pyon.util.unit_test import IonUnitTestCase
 from unittest import SkipTest
 from nose.plugins.attrib import attr
+from pyon.datastore.datastore import DatastoreManager
 
 
 @attr('UNIT', group='datastore')
 class TestState(IonUnitTestCase):
 
     def test_state(self):
-        state_repo = StateRepository.get_instance()
-        state_repo1 = StateRepository.get_instance()
+        dsm = DatastoreManager()
+        state_repo = StateRepository.get_instance(dsm)
+        state_repo1 = StateRepository.get_instance(dsm)
         self.assertEquals(state_repo, state_repo1)
 
         state1 = {'key':'value1'}

--- a/pyon/ion/test/test_state.py
+++ b/pyon/ion/test/test_state.py
@@ -15,9 +15,8 @@ class TestState(IonUnitTestCase):
 
     def test_state(self):
         dsm = DatastoreManager()
-        state_repo = StateRepository.get_instance(dsm)
-        state_repo1 = StateRepository.get_instance(dsm)
-        self.assertEquals(state_repo, state_repo1)
+        state_repo = StateRepository(dsm)
+        state_repo1 = StateRepository(dsm)
 
         state1 = {'key':'value1'}
         state_repo.put_state("id1", state1)

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -69,11 +69,6 @@ class IonIntegrationTestCase(unittest.TestCase):
 
     def _stop_container(self):
         if self.container:
-
-            # clean up singletons
-            # @TODO need to fix all of these
-            EventRepository.__instance = None
-
             self.container.stop()
             self.container = None
 

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -70,14 +70,11 @@ class IonIntegrationTestCase(unittest.TestCase):
     def _stop_container(self):
         if self.container:
 
-            # clean up singletons, datastore connections
+            # clean up singletons
             # @TODO need to fix all of these
             Directory.__instance = None
             StateRepository.__instance = None
             EventRepository.__instance = None
-            for x in DatastoreManager.datastores.itervalues():
-                x.close()
-            DatastoreManager.datastores = {}
 
             self.container.stop()
             self.container = None

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -72,7 +72,6 @@ class IonIntegrationTestCase(unittest.TestCase):
 
             # clean up singletons
             # @TODO need to fix all of these
-            Directory.__instance = None
             StateRepository.__instance = None
             EventRepository.__instance = None
 

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -72,7 +72,6 @@ class IonIntegrationTestCase(unittest.TestCase):
 
             # clean up singletons
             # @TODO need to fix all of these
-            StateRepository.__instance = None
             EventRepository.__instance = None
 
             self.container.stop()


### PR DESCRIPTION
These cause problems, especially between integration test runs.  Global state should be as isolated as possible - in our case, the Container instance is the one point for all of that.
- StateRepository
- EventRepository
- Directory

Only the EventRepository change has logical implications - EventPublishers must be constructed with a given EventRepository to gain functionality.  It's not perfect yet but better than having deps on a Container instance (which would have to late bind etc).  Can probably make a factory style pattern in the Container to create rigged up EventPublishers, or a more derived version of them that knows how to pull the correct event repo.
