### PR TITLE
Container Exchange API w/ auto EMS usage

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -144,11 +144,8 @@ class Container(BaseContainerAgent):
         self.event_repository = EventRepository()
         self._capabilities.append("EVENT_REPOSITORY")
 
-        # Start ExchangeManager. In particular establish broker connection
-        self.ex_manager.start()
-
-        # TODO: Move this in ExchangeManager - but there is an error
-        self.node, self.ioloop = messaging.make_node() # TODO: shortcut hack
+        # Start ExchangeManager, which starts the node (broker connection)
+        self.node, self.ioloop = self.ex_manager.start()
         self._capabilities.append("EXCHANGE_MANAGER")
 
         self.proc_manager.start()
@@ -269,5 +266,6 @@ class Container(BaseContainerAgent):
         log.error("Fail Fast: %s", err_msg)
         self.stop()
         log.error("Fail Fast: killing container")
+
         # The exit code of the terminated process is set to non-zero
         os.kill(os.getpid(), signal.SIGTERM)

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -290,7 +290,7 @@ class ProcManager(object):
 
         # Service RPC endpoint
         rsvc = ProcessRPCServer(node=self.container.node,
-                                name=listen_name,
+                                from_name=listen_name,
                                 service=service_instance,
                                 process=service_instance)
         # Start an ION process with the right kind of endpoint factory

--- a/pyon/event/event.py
+++ b/pyon/event/event.py
@@ -46,7 +46,7 @@ class EventPublisher(Publisher):
 
         self.event_repo = event_repo
 
-        Publisher.__init__(self, name=name, **kwargs)
+        Publisher.__init__(self, to_name=name, **kwargs)
 
     def _topic(self, origin):
         """
@@ -90,7 +90,7 @@ class EventPublisher(Publisher):
     def publish_event(self, event_msg, origin=None, **kwargs):
         assert origin
 
-        to_name = (self.name[0], self._topic(origin))
+        to_name = (self._send_name.exchange, self._topic(origin))
         log.debug("Publishing message to %s", to_name)
 
         ep = self.publish(event_msg, to_name=to_name)
@@ -140,7 +140,7 @@ class EventSubscriber(Subscriber):
 
         name = (xp_name, queue_name)
 
-        Subscriber.__init__(self, name=name, binding=binding, callback=callback, **kwargs)
+        Subscriber.__init__(self, from_name=name, binding=binding, callback=callback, **kwargs)
 
 #############################################################################
 #

--- a/pyon/event/test/test_event.py
+++ b/pyon/event/test/test_event.py
@@ -29,10 +29,12 @@ class TestEventPublisher(IonUnitTestCase):
         self._pub = EventPublisher(node=self._node)
 
     def test_init(self):
-        self.assertEquals(self._pub.name, ("%s.pyon.events" % bootstrap.sys_name, None))
+        self.assertEquals(self._pub._send_name.exchange, "%s.pyon.events" % bootstrap.sys_name)
+        self.assertEquals(self._pub._send_name.queue, None)
 
         pub = EventPublisher(node=self._node, xp=sentinel.xp)
-        self.assertEquals(pub.name, (sentinel.xp, None))
+        self.assertEquals(pub._send_name.exchange, sentinel.xp)
+        self.assertEquals(pub._send_name.queue, None)
 
     def test__topic_no_origin(self):
         self.assertRaises(AssertionError, self._pub._topic, None)
@@ -159,13 +161,15 @@ class TestEventSubscriber(IonUnitTestCase):
         self._sub = EventSubscriber(node=self._node, callback=self._cb)
 
     def test_init(self):
-        self.assertEquals(self._sub.name, ("%s.pyon.events" % bootstrap.sys_name, None))
+        self.assertEquals(self._sub._recv_name.exchange, "%s.pyon.events" % bootstrap.sys_name)
+        self.assertEquals(self._sub._recv_name.queue, None)
         self.assertEquals(self._sub._binding, "*.#")
         self.assertEquals(self._sub._callback, self._cb)
 
     def test_init_with_xp(self):
         sub = EventSubscriber(node=self._node, callback=self._cb, xp_name=sentinel.xp)
-        self.assertEquals(sub.name, (sentinel.xp, None))
+        self.assertEquals(sub._recv_name.exchange, sentinel.xp)
+        self.assertEquals(sub._recv_name.queue, None)
 
     def test_init_with_event_name(self):
         sub = EventSubscriber(node=self._node, callback=self._cb, event_name=sentinel.event_name)
@@ -177,12 +181,14 @@ class TestEventSubscriber(IonUnitTestCase):
 
     def test_init_with_queue_name(self):
         sub = EventSubscriber(node=self._node, callback=self._cb, xp_name=sentinel.xp, queue_name=str(sentinel.queue))
-        self.assertEquals(sub.name, (sentinel.xp, "%s.%s" % (bootstrap.sys_name, str(sentinel.queue))))
+        self.assertEquals(sub._recv_name.exchange, sentinel.xp)
+        self.assertEquals(sub._recv_name.queue, "%s.%s" % (bootstrap.sys_name, str(sentinel.queue)))
 
     def test_init_with_queue_name_with_sysname(self):
         queue_name = "%s-dacshund" % bootstrap.sys_name
         sub = EventSubscriber(node=self._node, callback=self._cb, xp_name=sentinel.xp, queue_name=queue_name)
-        self.assertEquals(sub.name, (sentinel.xp, queue_name))
+        self.assertEquals(sub._recv_name.exchange, sentinel.xp)
+        self.assertEquals(sub._recv_name.queue, queue_name)
 
     def test__topic(self):
         self.assertEquals(self._sub._topic(None), "*.#")

--- a/pyon/ion/endpoint.py
+++ b/pyon/ion/endpoint.py
@@ -36,8 +36,8 @@ class StreamPublisher(ProcessPublisher):
 
         """
         # Once EMS exists - remove the declare!
-        def _declare_exchange_point(self, xp):
-            log.debug("StreamPublisher passing on _declare_exchange_point: %s", xp)
+        def _declare_exchange(self, xp):
+            log.debug("StreamPublisher passing on _declare_exchange: %s", xp)
         """
     channel_type = NoDeclarePublisherChannel
 
@@ -118,8 +118,8 @@ class StreamSubscriber(ProcessSubscriber):
 
         """
         # Once EMS exists - remove the declare!
-        def _declare_exchange_point(self, xp):
-            log.debug("StreamSubscriber passing on _declare_exchange_point: %s", xp)
+        def _declare_exchange(self, xp):
+            log.debug("StreamSubscriber passing on _declare_exchange: %s", xp)
         """
 
     channel_type = NoBindSubscriberChannel

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -311,7 +311,6 @@ class ExchangeName(XOTransport, NamePair):
         queue = self._queue
         if self._queue and not self.exchange in self._queue:
             queue = ".".join([self.exchange, self._queue])
-            log.debug('Auto-prepending exchange to queue name for anti-clobbering: %s', queue)
 
         return queue
 

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -304,11 +304,16 @@ class ExchangeName(XOTransport, NamePair):
         return queue
 
     def declare(self, durable=False, auto_delete=True):
-        self.declare_queue_impl(None, self.queue, durable=durable, auto_delete=auto_delete)
+        return self.declare_queue_impl(None, self.queue, durable=durable, auto_delete=auto_delete)
 
     def delete(self):
         self.delete_queue_impl(None, self.queue)
 
+    def bind(self, binding_key):
+        self.bind_impl(None, self.exchange, self.queue, binding_key)
+
+    def unbind(self, binding_key):
+        self.unbind_impl(None, self.exchange, self.queue, binding_key)
 
 class ExchangePoint(ExchangeName):
     """

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -9,6 +9,7 @@ from pyon.net import messaging
 from pyon.util.log import log
 from pyon.core import bootstrap
 from pyon.util.async import blocking_cb
+from pyon.net.transport import BaseTransport, NamePair, AMQPTransport
 
 ION_URN_PREFIX = "urn:ionx"
 
@@ -35,7 +36,7 @@ class ExchangeManager(object):
             setattr(self.container, call.__name__, call)
 
         self.xs_by_name = {}
-        self.default_xs = ExchangeSpace(ION_ROOT_XS)
+        self.default_xs = ExchangeSpace(self, ION_ROOT_XS)
 
         self._chan = None
 
@@ -48,165 +49,313 @@ class ExchangeManager(object):
         # @TODO: raise error if sux
         node, ioloop = messaging.make_node()
 
+        self._transport = AMQPTransport.get_instance()
+        self._client    = self._get_channel(node)
+
         # Declare root exchange
         #self.default_xs.ensure_exists(self._get_channel())
         return node, ioloop
 
-    def _get_channel(self):
+    def _get_channel(self, node):
         """
         Get a raw channel to be used by all the ensure_exists methods.
         """
-        assert self.container and self.container.node
+        assert self.container
 
         # @TODO: needs lock, but so do all these methods
         if not self._chan:
-            self._chan = blocking_cb(self.container.node.client.channel, 'on_open_callback')
+            self._chan = blocking_cb(node.client.channel, 'on_open_callback')
 
         return self._chan
 
     def create_xs(self, name):
         log.debug("ExchangeManager.create_xs: %s", name)
-        xs = ExchangeSpace(name)
-        xs.ensure_exists(self._get_channel())
+        xs = ExchangeSpace(self, name)
+        xs.declare()
+        #xs.ensure_exists(self._get_channel())
 
         return xs
 
     def delete_xs(self, xs):
         log.debug("ExchangeManager.delete_xs: %s", xs.build_xname())
-        xs.delete(self._get_channel())
+        #xs.delete(self._get_channel())
 
     def create_xp(self, xs, name, xptype):
         log.debug("ExchangeManager.create_xp: name=%s, xptype=%s", name, xptype)
-        xp = ExchangePoint(name, xs=xs, xptype=xptype)
-        xp.ensure_exists(self._get_channel())
+        xp = ExchangePoint(self, xs, name, xptype)
+        xp.declare()
 
         return xp
 
     def delete_xp(self, xp):
         log.debug("ExchangeManager.delete_xp: name=%s", xp.build_xname())
-        xp.delete(self._get_channel())
+        xp.delete()
 
     def create_xn(self, xs, name):
         log.debug("ExchangeManager.create_xn: name=%s, xs=%s", name, xs)
-        xn = ExchangeName(name, xs)
-        #xn.ensure_exists(self._get_channel())
+        xn = ExchangeName(self, xs, name)
+        xn.declare()
 
         return xn
 
     def delete_xn(self, xn):
         log.debug("ExchangeManager.delete_xn: name=%s", xn.build_xlname())
-        # @TODO: noop?
-        pass
+        xn.delete()
 
     def stop(self, *args, **kwargs):
         log.debug("ExchangeManager stopping ...")
 
+    # transport implementations - XOTransport objects call here
+    def declare_exchange(self, exchange, exchange_type='topic', durable=False, auto_delete=True):
+        log.info("ExchangeManager.declare_exchange")
+        self._transport.declare_exchange_impl(self._client, exchange, exchange_type=exchange_type, durable=durable, auto_delete=auto_delete)
+    def delete_exchange(self, exchange, **kwargs):
+        log.info("ExchangeManager.delete_exchange")
+        self._transport.delete_exchange_impl(self._client, exchange, **kwargs)
+    def declare_queue(self, queue, durable=False, auto_delete=True):
+        log.info("ExchangeManager.declare_queue")
+        self._transport.declare_queue_impl(self._client, queue, durable=durable, auto_delete=auto_delete)
+    def delete_queue(self, queue, **kwargs):
+        log.info("ExchangeManager.delete_queue")
+        self._transport.delete_queue_impl(self._client, queue, **kwargs)
+    def bind(self, exchange, queue, binding):
+        log.info("ExchangeManager.bind")
+        self._transport.bind_impl(self._client, exchange, queue, binding)
+    def unbind(self, exchange, queue, binding):
+        log.info("ExchangeManager.unbind")
+        self._transport.unbind_impl(self._client, exchange, queue, binding)
 
-class ExchangeSpace(object):
+#
+#class ExchangeSpace(object):
+#    ION_DEFAULT_XS = "ioncore"
+#
+#    def __init__(self, name):
+#        assert name, "Invalid XS name %s" % name
+#        name = str(name)
+#        if name.startswith(ION_URN_PREFIX):
+#            name = name[len(ION_URN_PREFIX)+1:]
+#        assert valid_xname(name), "Invalid XS name %s" % name
+#        self.name = name
+#        self.qname = self.build_qname()
+#
+#    def build_qname(self):
+#        qname = "%s:%s:%s" % (ION_URN_PREFIX, bootstrap.sys_name, self.name)
+#        return qname
+#
+#    def build_xname(self):
+#        xname = "%s.ion.xs.%s" % (bootstrap.sys_name, self.name)
+#        return xname
+#
+#    def ensure_exists(self, chan):
+#        xname = self.build_xname()
+#        log.debug("ExchangeSpace.ensure_exists() xname=%s", xname)
+#
+#        blocking_cb(chan.exchange_declare, 'callback', exchange=xname,
+#                                                       type='topic',
+#                                                       durable=False,
+#                                                       auto_delete=True)
+#
+#        log.debug("ExchangeSpace (%s) created", xname)
+#
+#    def delete(self, chan):
+#        xname = self.build_xname()
+#        log.debug("ExchangeSpace.delete, xname: %s", xname)
+#
+#        blocking_cb(chan.exchange_delete, 'callback', exchange=xname)
+#
+#        log.debug("ExchangeSpace (%s) deleted", xname)
+#
+#    def __str__(self):
+#        return self.name
+#
+#    def __repr__(self):
+#        return "ExchangeSpace(%s)" % self.qname
+#
+#class ExchangeName(object):
+#    """
+#    Exchange names have the following format:
+#    urn:ionx:<XS-Name>:<Name>
+#    """
+#    def __init__(self, name, xs=None):
+#        assert name, "Invalid XS name %s" % name
+#        name = str(name)
+#        if name.startswith(ION_URN_PREFIX):
+#            name = name[len(ION_URN_PREFIX)+1:]
+#            xs, name = name.split(":")
+#        assert xs, "XS not given"
+#        assert valid_xname(name), "Invalid XN name %s" % name
+#        self.xs = xs
+#        self.name = str(name)
+#        self.qname = self.build_qname()
+#
+#    def build_qname(self):
+#        qname = "%s:%s:%s:%s" % (ION_URN_PREFIX, bootstrap.sys_name, str(self.xs), self.name)
+#        return qname
+#
+#    def build_xlname(self):
+#        xname = "%s.ion.xs.%s" % (bootstrap.sys_name, self.name)
+#        return xname
+#
+#    def __str__(self):
+#        return self.name
+#
+#    def __repr__(self):
+#        return "ExchangeName(%s)" % self.qname
+#
+#class ExchangePoint(ExchangeName):
+#    XPTYPES = {
+#        'basic':'basic',
+#        'ttree':'ttree',
+#    }
+#    def __init__(self, name, xs=None, xptype=None):
+#        ExchangeName.__init__(self, name, xs)
+#        self.xptype = xptype or 'basic'
+#
+#    def build_xname(self):
+#        xname = "%s.xp.%s" % (self.xs.build_xname(), self.name)
+#        return xname
+#
+#    def ensure_exists(self, chan):
+#
+#        xname = self.build_xname()
+#        log.debug("ExchangePoint.ensure_exists, xname=%s", xname)
+#
+#        blocking_cb(chan.exchange_declare, 'callback', exchange=xname,
+#                                                       type='topic',
+#                                                       durable=False,
+#                                                       auto_delete=True)
+#
+#        log.debug("ExchangePoint (%s) created", xname)
+#
+#    def delete(self, chan):
+#        xname = self.build_xname()
+#        log.debug("ExchangePoint.delete, xname: %s", xname)
+#
+#        blocking_cb(chan.exchange_delete, 'callback', exchange=xname)
+#
+#        log.debug("ExchangePoint (%s) deleted", xname)
+
+
+
+class XOTransport(BaseTransport):
+    def __init__(self, exchange_manager):
+        self._exchange_manager = exchange_manager
+
+    def declare_exchange_impl(self, client, exchange, **kwargs):
+        return self._exchange_manager.declare_exchange(exchange, **kwargs)
+
+    def delete_exchange_impl(self, client, exchange, **kwargs):
+        return self._exchange_manager.delete_exchange(exchange, **kwargs)
+
+    def declare_queue_impl(self, client, queue, **kwargs):
+        return self._exchange_manager.declare_queue(queue, **kwargs)
+
+    def delete_queue_impl(self, client, queue, **kwargs):
+        return self._exchange_manager.delete_queue(queue, **kwargs)
+
+    def bind_impl(self, client, exchange, queue, binding):
+        return self._exchange_manager.bind(exchange, queue, binding)
+
+    def unbind_impl(self, client, exchange, queue, binding):
+        return self._exchange_manager.unbind(exchange, queue, binding)
+
+#    # friendly versions?
+#    def declare_exchange(self, exchange, **kwargs):
+#        return self.declare_exchange_impl(None, exchange, **kwargs)
+#
+#        # etc etc
+
+class ExchangeSpace(XOTransport, NamePair):
+
     ION_DEFAULT_XS = "ioncore"
 
-    def __init__(self, name):
-        assert name, "Invalid XS name %s" % name
-        name = str(name)
-        if name.startswith(ION_URN_PREFIX):
-            name = name[len(ION_URN_PREFIX)+1:]
-        assert valid_xname(name), "Invalid XS name %s" % name
-        self.name = name
-        self.qname = self.build_qname()
+    def __init__(self, exchange_manager, exchange):
+        XOTransport.__init__(self, exchange_manager=exchange_manager)
+        NamePair.__init__(self, exchange=exchange)
 
-    def build_qname(self):
-        qname = "%s:%s:%s" % (ION_URN_PREFIX, bootstrap.sys_name, self.name)
-        return qname
+    @property
+    def exchange(self):
+        return "%s.ion.xs.%s" % (bootstrap.get_sys_name(), self._exchange)
 
-    def build_xname(self):
-        xname = "%s.ion.xs.%s" % (bootstrap.sys_name, self.name)
-        return xname
+    def declare(self, exchange_type='topic', durable=False, auto_delete=True):
+        self.declare_exchange_impl(None, self.exchange, exchange_type=exchange_type, durable=durable, auto_delete=auto_delete)
 
-    def ensure_exists(self, chan):
-        xname = self.build_xname()
-        log.debug("ExchangeSpace.ensure_exists() xname=%s", xname)
+    def delete(self):
+        self.delete_exchange_impl(None, self.exchange)
 
-        blocking_cb(chan.exchange_declare, 'callback', exchange=xname,
-                                                       type='topic',
-                                                       durable=False,
-                                                       auto_delete=True)
+class ExchangeName(XOTransport, NamePair):
+    def __init__(self, exchange_manager, xs, name):
+        XOTransport.__init__(self, exchange_manager=exchange_manager)
+        NamePair.__init__(self, exchange=None, queue=name)
+        self._xs = xs
 
-        log.debug("ExchangeSpace (%s) created", xname)
+    @property
+    def exchange(self):
+        return self._xs.exchange
 
-    def delete(self, chan):
-        xname = self.build_xname()
-        log.debug("ExchangeSpace.delete, xname: %s", xname)
+    @property
+    def queue(self):
+        # make sure prefixed with sysname?
+        queue = self._queue
+        if self._queue and not self.exchange in self._queue:
+            queue = ".".join([self.exchange, self._queue])
+            log.debug('Auto-prepending exchange to queue name for anti-clobbering: %s', queue)
 
-        blocking_cb(chan.exchange_delete, 'callback', exchange=xname)
+        return queue
 
-        log.debug("ExchangeSpace (%s) deleted", xname)
+    def declare(self, durable=False, auto_delete=True):
+        self.declare_queue_impl(None, self.queue, durable=durable, auto_delete=auto_delete)
 
-    def __str__(self):
-        return self.name
+    def delete(self):
+        self.delete_queue_impl(None, self.queue)
 
-    def __repr__(self):
-        return "ExchangeSpace(%s)" % self.qname
-
-class ExchangeName(object):
-    """
-    Exchange names have the following format:
-    urn:ionx:<XS-Name>:<Name>
-    """
-    def __init__(self, name, xs=None):
-        assert name, "Invalid XS name %s" % name
-        name = str(name)
-        if name.startswith(ION_URN_PREFIX):
-            name = name[len(ION_URN_PREFIX)+1:]
-            xs, name = name.split(":")
-        assert xs, "XS not given"
-        assert valid_xname(name), "Invalid XN name %s" % name
-        self.xs = xs
-        self.name = str(name)
-        self.qname = self.build_qname()
-
-    def build_qname(self):
-        qname = "%s:%s:%s:%s" % (ION_URN_PREFIX, bootstrap.sys_name, str(self.xs), self.name)
-        return qname
-
-    def build_xlname(self):
-        xname = "%s.ion.xs.%s" % (bootstrap.sys_name, self.name)
-        return xname
-
-    def __str__(self):
-        return self.name
-
-    def __repr__(self):
-        return "ExchangeName(%s)" % self.qname
 
 class ExchangePoint(ExchangeName):
+    """
+    @TODO is this really an ExchangeName? seems more inline with XS
+    @TODO a nameable ExchangePoint - to be able to create a named queue that receives routed
+            messages from the XP.
+    """
     XPTYPES = {
         'basic':'basic',
         'ttree':'ttree',
-    }
-    def __init__(self, name, xs=None, xptype=None):
-        ExchangeName.__init__(self, name, xs)
-        self.xptype = xptype or 'basic'
+        }
 
-    def build_xname(self):
-        xname = "%s.xp.%s" % (self.xs.build_xname(), self.name)
-        return xname
+    def __init__(self, exchange_manager, xs, name, xptype):
+        XOTransport.__init__(self, exchange_manager=exchange_manager)
+        NamePair.__init__(self, exchange=name)
 
-    def ensure_exists(self, chan):
+        self._xs = xs
+        self._xptype = xptype or 'ttree'
 
-        xname = self.build_xname()
-        log.debug("ExchangePoint.ensure_exists, xname=%s", xname)
+    @property
+    def exchange(self):
+        return "%s.xp.%s" % (self._xs.exchange, self._exchange)
 
-        blocking_cb(chan.exchange_declare, 'callback', exchange=xname,
-                                                       type='topic',
-                                                       durable=False,
-                                                       auto_delete=True)
+    @property
+    def queue(self):
+        return None     # @TODO: correct?
 
-        log.debug("ExchangePoint (%s) created", xname)
+    def declare(self):
+        self.declare_exchange_impl(None, self.exchange)
 
-    def delete(self, chan):
-        xname = self.build_xname()
-        log.debug("ExchangePoint.delete, xname: %s", xname)
+    def delete(self):
+        self.delete_exchange_impl(None, self.exchange)
 
-        blocking_cb(chan.exchange_delete, 'callback', exchange=xname)
 
-        log.debug("ExchangePoint (%s) deleted", xname)
+
+
+
+
+# @TODO: these are first class objects yes?
+class ProcessExchangeName(ExchangeName):
+    pass
+
+class ServiceExchangeName(ExchangeName):
+    pass
+
+#class ExchangePoint(ExchangeName):
+#    pass
+
+class QueueExchangeName(ExchangeName):
+    pass

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -9,7 +9,7 @@ from pyon.net import messaging
 from pyon.util.log import log
 from pyon.core import bootstrap
 from pyon.util.async import blocking_cb
-from pyon.net.transport import BaseTransport, NamePair, AMQPTransport
+from pyon.net.transport import BaseTransport, NameTrio, AMQPTransport
 from interface.objects import ExchangeName as ResExchangeName
 from interface.objects import ExchangeSpace as ResExchangeSpace
 from interface.objects import ExchangePoint as ResExchangePoint
@@ -423,13 +423,13 @@ class XOTransport(BaseTransport):
 #
 #        # etc etc
 
-class ExchangeSpace(XOTransport, NamePair):
+class ExchangeSpace(XOTransport, NameTrio):
 
     ION_DEFAULT_XS = "ioncore"
 
     def __init__(self, exchange_manager, exchange, exchange_type='topic', durable=False, auto_delete=True):
         XOTransport.__init__(self, exchange_manager=exchange_manager)
-        NamePair.__init__(self, exchange=exchange)
+        NameTrio.__init__(self, exchange=exchange)
 
         self._xs_exchange_type = exchange_type
         self._xs_durable       = durable
@@ -448,7 +448,7 @@ class ExchangeSpace(XOTransport, NamePair):
     def delete(self):
         self.delete_exchange_impl(None, self.exchange)
 
-class ExchangeName(XOTransport, NamePair):
+class ExchangeName(XOTransport, NameTrio):
 
     xn_type = "XN_BASE"
 
@@ -457,7 +457,7 @@ class ExchangeName(XOTransport, NamePair):
 
     def __init__(self, exchange_manager, name, xs, durable=None, auto_delete=None):
         XOTransport.__init__(self, exchange_manager=exchange_manager)
-        NamePair.__init__(self, exchange=None, queue=name)
+        NameTrio.__init__(self, exchange=None, queue=name)
 
         self._xs = xs
 
@@ -513,7 +513,7 @@ class ExchangePoint(ExchangeName):
         xptype = xptype or 'ttree'
 
         XOTransport.__init__(self, exchange_manager=exchange_manager)
-        NamePair.__init__(self, exchange=name)
+        NameTrio.__init__(self, exchange=name)
 
         self._xs        = xs
         self._xptype    = xptype

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -105,14 +105,16 @@ class ExchangeManager(object):
         #self.default_xs.ensure_exists(self._get_channel())
         return node, ioloop
 
-    def _ems_available(self):
+    def _ems_available(self, use_ems=False):
         """
         Returns True if the EMS is (likely) available and the auto_register CFG entry is True.
 
         Has the side effect of bootstrapping the org_id and default_xs's id/rev from the RR.
         Therefore, cannot be a property.
+
+        @param  use_ems     If True, don't bother checking Config for auto_register key.
         """
-        if CFG.container.exchange.auto_register:
+        if use_ems or CFG.container.get('exchange', {}).get('auto_register', False):
             # ok now make sure it's in the directory
             des = self.container.directory.find_entries('/Containers')
             for de in des:
@@ -143,14 +145,14 @@ class ExchangeManager(object):
 
         return self._chan
 
-    def create_xs(self, name, exchange_type='topic', durable=False, auto_delete=True):
+    def create_xs(self, name, use_ems=False, exchange_type='topic', durable=False, auto_delete=True):
         log.debug("ExchangeManager.create_xs: %s", name)
         xs = ExchangeSpace(self, name, exchange_type=exchange_type, durable=durable, auto_delete=auto_delete)
         xs.declare()
 
         self.xs_by_name[name] = xs
 
-        if self._ems_available():
+        if self._ems_available(use_ems):
             # create a RR object
             xso = ResExchangeSpace(name=name)
             xso_id = self._ems_client.create_exchange_space(xso, self.org_id)
@@ -159,7 +161,7 @@ class ExchangeManager(object):
 
         return xs
 
-    def delete_xs(self, xs):
+    def delete_xs(self, xs, use_ems=False):
         """
         @type xs    ExchangeSpace
         """
@@ -169,12 +171,12 @@ class ExchangeManager(object):
         name = xs._exchange     # @TODO this feels wrong
         del self.xs_by_name[name]
 
-        if self._ems_available():
+        if self._ems_available(use_ems):
             xso = self._get_xs_obj(name)
             self._ems_client.delete_exchange_space(xso._id)
             del self._xs_cache[name]
 
-    def create_xp(self, name, xs=None, **kwargs):
+    def create_xp(self, name, xs=None, use_ems=False, **kwargs):
         log.debug("ExchangeManager.create_xp: %s", name)
         xs = xs or self.default_xs
         xp = ExchangePoint(self, name, xs, **kwargs)
@@ -183,21 +185,21 @@ class ExchangeManager(object):
         # put in xn_by_name anyway
         self.xn_by_name[name] = xp
 
-        if self._ems_available():
+        if self._ems_available(use_ems):
             # create an RR object
             xpo = ResExchangePoint(name=name, topology_type=xp._xptype)
             xpo_id = self._ems_client.create_exchange_point(xpo, self._get_xs_obj(xs._exchange)._id)        # @TODO: _exchange is wrong
 
         return xp
 
-    def delete_xp(self, xp):
+    def delete_xp(self, xp, use_ems=False):
         log.debug("ExchangeManager.delete_xp: name=%s", 'TODO') #xp.build_xname())
         xp.delete()
 
         name = xp._exchange # @TODO: not right
         del self.xn_by_name[name]
 
-        if self._ems_available():
+        if self._ems_available(use_ems):
             # find the XP object via RR
             xpo_ids = self._rr_client.find_resources(RT.ExchangePoint, name=name, id_only=True)
             if not (len(xpo_ids) and len(xpo_ids[0]) == 1):
@@ -206,7 +208,7 @@ class ExchangeManager(object):
             xpo_id = xpo_ids[0][0]
             self._ems_client.delete_exchange_point(xpo_id)
 
-    def _create_xn(self, xn_type, name, xs=None, **kwargs):
+    def _create_xn(self, xn_type, name, xs=None, use_ems=False, **kwargs):
         xs = xs or self.default_xs
         log.debug("ExchangeManager._create_xn: type: %s, name=%s, xs=%s, kwargs=%s", xn_type, name, xs, kwargs)
 
@@ -222,7 +224,7 @@ class ExchangeManager(object):
         xn.declare()
         self.xn_by_name[name] = xn
 
-        if self._ems_available():
+        if self._ems_available(use_ems):
             xno = ResExchangeName(name=name, xn_type=xn.xn_type)
             self._ems_client.declare_exchange_name(xno, self._get_xs_obj(xs._exchange)._id)     # @TODO: exchange is wrong
 
@@ -237,14 +239,14 @@ class ExchangeManager(object):
     def create_xn_queue(self, name, xs=None, **kwargs):
         return self._create_xn('queue', name, xs=xs, **kwargs)
 
-    def delete_xn(self, xn):
+    def delete_xn(self, xn, use_ems=False):
         log.debug("ExchangeManager.delete_xn: name=%s", "TODO") #xn.build_xlname())
         xn.delete()
 
         name = xn._queue                # @TODO feels wrong
         del self.xn_by_name[name]
 
-        if self._ems_available():
+        if self._ems_available(use_ems):
             # find the XN object via RR?
             xno_ids = self._rr_client.find_resources(RT.ExchangeName, name=name, id_only=True)
             if not (len(xno_ids) and len(xno_ids[0]) == 1):

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -116,7 +116,7 @@ class ExchangeManager(object):
         self._transport.delete_exchange_impl(self._client, exchange, **kwargs)
     def declare_queue(self, queue, durable=False, auto_delete=True):
         log.info("ExchangeManager.declare_queue")
-        self._transport.declare_queue_impl(self._client, queue, durable=durable, auto_delete=auto_delete)
+        return self._transport.declare_queue_impl(self._client, queue, durable=durable, auto_delete=auto_delete)
     def delete_queue(self, queue, **kwargs):
         log.info("ExchangeManager.delete_queue")
         self._transport.delete_queue_impl(self._client, queue, **kwargs)

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -261,6 +261,10 @@ class XOTransport(BaseTransport):
     def unbind_impl(self, client, exchange, queue, binding):
         return self._exchange_manager.unbind(exchange, queue, binding)
 
+    def setup_listener(self, binding, default_cb):
+        log.debug("XOTransport passing on setup_listener")
+        pass
+
 #    # friendly versions?
 #    def declare_exchange(self, exchange, **kwargs):
 #        return self.declare_exchange_impl(None, exchange, **kwargs)
@@ -325,6 +329,13 @@ class ExchangeName(XOTransport, NamePair):
 
     def unbind(self, binding_key):
         self.unbind_impl(None, self.exchange, self.queue, binding_key)
+
+    def setup_listener(self, binding, default_cb):
+        log.debug("ExchangeName.setup_listener: B %s", binding)
+
+        # make sure we've bound (idempotent action)
+        self.bind(binding)
+
 
 class ExchangePoint(ExchangeName):
     """

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -13,8 +13,8 @@ from pyon.net.transport import BaseTransport, NameTrio, AMQPTransport
 from interface.objects import ExchangeName as ResExchangeName
 from interface.objects import ExchangeSpace as ResExchangeSpace
 from interface.objects import ExchangePoint as ResExchangePoint
-from interface.services.coi.iexchange_management_service import ExchangeManagementServiceClient
-from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
+from interface.services.coi.iexchange_management_service import ExchangeManagementServiceProcessClient
+from interface.services.coi.iresource_registry_service import ResourceRegistryServiceProcessClient
 from pyon.util.config import CFG
 from pyon.ion.resource import RT
 
@@ -57,8 +57,8 @@ class ExchangeManager(object):
 
         self._chan = None
 
-        self._ems_client    = ExchangeManagementServiceClient()
-        self._rr_client     = ResourceRegistryServiceClient()
+        self._ems_client    = ExchangeManagementServiceProcessClient(process=self.container)
+        self._rr_client     = ResourceRegistryServiceProcessClient(process=self.container)
 
         # TODO: Do more initializing here, not in container
 

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -71,6 +71,10 @@ class ExchangeManager(object):
 
         return xs
 
+    def delete_xs(self, xs):
+        log.debug("ExchangeManager.delete_xs: %s", xs.build_xname())
+        xs.delete(self._get_channel())
+
     def create_xp(self, xs, name, xptype):
         log.debug("ExchangeManager.create_xp: name=%s, xptype=%s", name, xptype)
         xp = ExchangePoint(name, xs=xs, xptype=xptype)
@@ -78,12 +82,21 @@ class ExchangeManager(object):
 
         return xp
 
+    def delete_xp(self, xp):
+        log.debug("ExchangeManager.delete_xp: name=%s", xp.build_xname())
+        xp.delete(self._get_channel())
+
     def create_xn(self, xs, name):
         log.debug("ExchangeManager.create_xn: name=%s, xs=%s", name, xs)
         xn = ExchangeName(name, xs)
         #xn.ensure_exists(self._get_channel())
 
         return xn
+
+    def delete_xn(self, xn):
+        log.debug("ExchangeManager.delete_xn: name=%s", xn.build_xlname())
+        # @TODO: noop?
+        pass
 
     def stop(self, *args, **kwargs):
         log.debug("ExchangeManager stopping ...")
@@ -119,6 +132,14 @@ class ExchangeSpace(object):
                                                        auto_delete=True)
 
         log.debug("ExchangeSpace (%s) created", xname)
+
+    def delete(self, chan):
+        xname = self.build_xname()
+        log.debug("ExchangeSpace.delete, xname: %s", xname)
+
+        blocking_cb(chan.exchange_delete, 'callback', exchange=xname)
+
+        log.debug("ExchangeSpace (%s) deleted", xname)
 
     def __str__(self):
         return self.name
@@ -182,3 +203,10 @@ class ExchangePoint(ExchangeName):
 
         log.debug("ExchangePoint (%s) created", xname)
 
+    def delete(self, chan):
+        xname = self.build_xname()
+        log.debug("ExchangePoint.delete, xname: %s", xname)
+
+        blocking_cb(chan.exchange_delete, 'callback', exchange=xname)
+
+        log.debug("ExchangePoint (%s) deleted", xname)

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -383,7 +383,7 @@ class TestExchangeObjectsCreateDelete(IonIntegrationTestCase):
     def test_delete_xn(self):
         # same as the other deletes except with queues instead
 
-        xn = self.container.ex_manager.create_service_xn('test_service')
+        xn = self.container.ex_manager.create_xn_service('test_service')
 
         # prove queue is declared already (can't declare the same named one with diff params)
         ch = self.container.node.channel(RecvChannel)
@@ -398,10 +398,12 @@ class TestExchangeObjectsCreateDelete(IonIntegrationTestCase):
 
         # grab another channel and declare (should work fine this time)
         ch = self.container.node.channel(RecvChannel)
-        ch._exchange_auto_delete = not xp._xs._xs_auto_delete
+        ch._exchange_auto_delete = not xn._xs._xs_auto_delete
 
-        ch._declare_exchange(xp.exchange)
+        # must set recv_name
+        ch._recv_name = xn
+        ch._declare_queue(xn.queue)
 
         # cool, now cleanup (we don't expose this via Channel)
         at = AMQPTransport.get_instance()
-        at.delete_exchange_impl(ch._amq_chan, xp.exchange)
+        at.delete_queue_impl(ch._amq_chan, xn.queue)

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pyon.core.bootstrap import get_sys_name
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 
@@ -10,7 +11,7 @@ from interface.services.examples.hello.ihello_service import HelloServiceClient
 from pyon.net.endpoint import RPCServer
 from pyon.util.async import spawn
 import unittest
-from pyon.ion.exchange import ExchangeManager, ION_ROOT_XS, ExchangeNameProcess
+from pyon.ion.exchange import ExchangeManager, ION_ROOT_XS, ExchangeNameProcess, ExchangeSpace, ExchangePoint, ExchangeNameService, ExchangeName, ExchangeNameQueue
 from mock import Mock, sentinel
 from pyon.net.transport import BaseTransport
 
@@ -20,6 +21,7 @@ class TestExchangeObjects(IonUnitTestCase):
         self.ex_manager = ExchangeManager(Mock())
         self.ex_manager._transport  = Mock(BaseTransport)
         self.ex_manager._client     = Mock()
+        # all exchange level operations are patched out via the _transport
 
     def test_exchange_by_name(self):
         # defaults: Root XS, no XNs
@@ -53,6 +55,201 @@ class TestExchangeObjects(IonUnitTestCase):
         self.assertIn('xn3', self.ex_manager.xn_by_name)
         self.assertIn(xn3, self.ex_manager.xn_by_xs['exchange'])
         self.assertNotIn(xn3, self.ex_manager.xn_by_xs[ION_ROOT_XS])
+
+    def test_create_xs(self):
+        xs      = self.ex_manager.create_xs(sentinel.xs)
+        exstr   = '%s.ion.xs.%s' % (get_sys_name(), str(sentinel.xs))     # what we expect the exchange property to return
+
+        self.assertEquals(xs._exchange, sentinel.xs)
+        self.assertEquals(xs.exchange, exstr)
+        self.assertEquals(xs.queue, None)
+        self.assertEquals(xs.binding, None)
+
+        self.assertEquals(xs._xs_exchange_type, 'topic')
+        self.assertEquals(xs._xs_durable, False)
+        self.assertEquals(xs._xs_auto_delete, True)
+
+        # should be in our map too
+        self.assertIn(sentinel.xs, self.ex_manager.xs_by_name)
+        self.assertEquals(self.ex_manager.xs_by_name[sentinel.xs], xs)
+
+        # should've tried to declare
+        self.ex_manager._transport.declare_exchange_impl.assert_called_once_with(self.ex_manager._client, exstr, auto_delete=True, durable=False, exchange_type='topic')
+
+    def test_create_xs_with_params(self):
+        xs      = self.ex_manager.create_xs(sentinel.xs, exchange_type=sentinel.ex_type, durable=True)
+        exstr   = '%s.ion.xs.%s' % (get_sys_name(), str(sentinel.xs))     # what we expect the exchange property to return
+
+        self.assertEquals(xs._xs_durable, True)
+        self.assertEquals(xs._xs_exchange_type, sentinel.ex_type)
+
+        # declaration?
+        self.ex_manager._transport.declare_exchange_impl.assert_called_once_with(self.ex_manager._client, exstr, auto_delete=True, durable=True, exchange_type=sentinel.ex_type)
+
+    def test_delete_xs(self):
+        # need an XS first
+        xs      = self.ex_manager.create_xs(sentinel.delete_me)
+        exstr   = '%s.ion.xs.%s' % (get_sys_name(), str(sentinel.delete_me))     # what we expect the exchange property to return
+
+        self.assertIn(sentinel.delete_me, self.ex_manager.xs_by_name)
+
+        self.ex_manager.delete_xs(xs)
+
+        self.assertNotIn(sentinel.delete_me, self.ex_manager.xs_by_name)
+
+        # call to broker
+        self.ex_manager._transport.delete_exchange_impl.assert_called_once_with(self.ex_manager._client, exstr)
+
+    def test_delete_xs_without_creating_it_first(self):
+        xsmock = Mock(ExchangeSpace)
+        xsmock._exchange = sentinel.fake
+
+        self.assertRaises(KeyError, self.ex_manager.delete_xs, xsmock)
+
+    def test_create_xp(self):
+        xp      = self.ex_manager.create_xp(sentinel.xp)
+        exstr   = "%s.ion.xs.%s.xp.%s" % (get_sys_name(), self.ex_manager.default_xs._exchange, str(sentinel.xp))
+
+        self.assertEquals(xp._exchange, sentinel.xp)
+        self.assertEquals(xp._xs, self.ex_manager.default_xs)
+        self.assertEquals(xp._xptype, 'ttree')
+        self.assertEquals(xp._queue, None)
+        self.assertEquals(xp._binding, None)
+
+        self.assertEquals(xp.exchange, exstr)
+
+        # declaration
+        self.ex_manager._transport.declare_exchange_impl.assert_called_once_with(self.ex_manager._client, exstr, auto_delete=True, durable=False, exchange_type='topic')
+
+    def test_create_xp_with_params(self):
+        xp = self.ex_manager.create_xp(sentinel.xp, xptype=sentinel.xptype)
+        self.assertEquals(xp._xptype, sentinel.xptype)
+
+    def test_create_xp_with_different_xs(self):
+        xs = self.ex_manager.create_xs(sentinel.xs)
+        xs_exstr = '%s.ion.xs.%s' % (get_sys_name(), str(sentinel.xs))     # what we expect the exchange property to return
+
+        xp = self.ex_manager.create_xp(sentinel.xp, xs)
+        xp_exstr = '%s.xp.%s' % (xs_exstr, str(sentinel.xp))
+
+        # check mappings
+        self.assertIn(sentinel.xp, self.ex_manager.xn_by_name)
+        self.assertIn(xp, self.ex_manager.xn_by_xs[sentinel.xs])
+
+        self.assertEquals(xp.exchange, xp_exstr)
+
+    def test_delete_xp(self):
+        xp      = self.ex_manager.create_xp(sentinel.xp)
+        exstr   = "%s.ion.xs.%s.xp.%s" % (get_sys_name(), self.ex_manager.default_xs._exchange, str(sentinel.xp))
+
+        self.assertIn(sentinel.xp, self.ex_manager.xn_by_name)
+
+        self.ex_manager.delete_xp(xp)
+
+        self.assertNotIn(sentinel.xp, self.ex_manager.xn_by_name)
+
+        # deletion
+        self.ex_manager._transport.delete_exchange_impl.assert_called_once_with(self.ex_manager._client, exstr)
+
+    def test_delete_xp_without_creating_it_first(self):
+        xpmock = Mock(ExchangePoint)
+        xpmock._exchange = sentinel.delete_me
+
+        self.assertRaises(KeyError, self.ex_manager.delete_xp, xpmock)
+
+    def test__create_xn_unknown_type(self):
+        self.assertRaises(StandardError, self.ex_manager._create_xn, sentinel.unknown)
+
+    def test_create_xn_service(self):
+        xn      = self.ex_manager.create_xn_service('servicename')
+        qstr    = '%s.%s' % (xn.exchange, 'servicename')        # what we expect the queue name to look like
+
+        self.assertIsInstance(xn, ExchangeName)
+        self.assertIsInstance(xn, ExchangeNameService)
+
+        # exclusive attrs to XN
+        self.assertEquals(xn._xs, self.ex_manager.default_xs)
+        self.assertEquals(xn._xn_auto_delete, ExchangeNameService._xn_auto_delete)
+        self.assertEquals(xn._xn_durable, ExchangeNameService._xn_durable)
+        self.assertEquals(xn.xn_type, 'XN_SERVICE')
+
+        # underlying attrs
+        self.assertEquals(xn._exchange, None)
+        self.assertEquals(xn._queue, 'servicename')
+        self.assertEquals(xn._binding, None)
+
+        # top level props
+        self.assertEquals(xn.exchange, self.ex_manager.default_xs.exchange)
+        self.assertEquals(xn.queue, qstr)
+        self.assertEquals(xn.binding, 'servicename')
+
+        # should be in mapping
+        self.assertIn('servicename', self.ex_manager.xn_by_name)
+        self.assertIn(xn, self.ex_manager.xn_by_xs[ION_ROOT_XS])
+
+        # declaration
+        self.ex_manager._transport.declare_queue_impl.assert_called_once(self.ex_manager._client, qstr, durable=ExchangeNameService._xn_durable, auto_delete=ExchangeNameService._xn_auto_delete)
+
+    def test_create_xn_process(self):
+        xn = self.ex_manager.create_xn_process('procname')
+
+        self.assertIsInstance(xn, ExchangeName)
+        self.assertIsInstance(xn, ExchangeNameProcess)
+
+    def test_create_xn_queue(self):
+        xn = self.ex_manager.create_xn_queue('queuename')
+
+        self.assertIsInstance(xn, ExchangeName)
+        self.assertIsInstance(xn, ExchangeNameQueue)
+
+    def test_create_xn_with_different_xs(self):
+        xs = self.ex_manager.create_xs(sentinel.xs)
+        xs_exstr = '%s.ion.xs.%s' % (get_sys_name(), str(sentinel.xs))     # what we expect the exchange property to return
+
+        xn      = self.ex_manager.create_xn_service('servicename', xs)
+        qstr    = '%s.%s' % (xn.exchange, 'servicename')        # what we expect the queue name to look like
+
+        # check mappings
+        self.assertIn('servicename', self.ex_manager.xn_by_name)
+        self.assertIn(xn, self.ex_manager.xn_by_xs[sentinel.xs])
+
+        self.assertEquals(xn.queue, qstr)
+
+    def test_delete_xn(self):
+        xn      = self.ex_manager.create_xn_process('procname')
+        qstr    = '%s.%s' % (xn.exchange, 'procname')
+
+        self.assertIn('procname', self.ex_manager.xn_by_name)
+
+        self.ex_manager.delete_xn(xn)
+
+        self.assertNotIn('procname', self.ex_manager.xn_by_name)
+
+        # call to broker
+        self.ex_manager._transport.delete_queue_impl.assert_called_once_with(self.ex_manager._client, qstr)
+
+    def test_xn_setup_listener(self):
+        xn      = self.ex_manager.create_xn_service('servicename')
+        qstr    = '%s.%s' % (xn.exchange, 'servicename')        # what we expect the queue name to look like
+
+        xn.setup_listener(sentinel.binding, None)
+
+        self.ex_manager._transport.bind_impl.assert_called_once_with(self.ex_manager._client, xn.exchange, qstr, sentinel.binding)
+
+    def test_xn_bind(self):
+        xn      = self.ex_manager.create_xn_service('servicename')
+
+        xn.bind(sentinel.bind)
+
+        self.ex_manager._transport.bind_impl.assert_called_once_with(self.ex_manager._client, xn.exchange, xn.queue, sentinel.bind)
+
+    def test_xn_unbind(self):
+        xn      = self.ex_manager.create_xn_service('servicename')
+
+        xn.unbind(sentinel.bind)
+
+        self.ex_manager._transport.unbind_impl.assert_called_once_with(self.ex_manager._client, xn.exchange, xn.queue, sentinel.bind)
+
 
 @attr('INT', group='exchange')
 class TestExchangeObjectsInt(IonIntegrationTestCase):

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -1,17 +1,58 @@
 #!/usr/bin/env python
-import unittest
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 
 from pyon.util.int_test import IonIntegrationTestCase
+from pyon.util.unit_test import IonUnitTestCase
 from nose.plugins.attrib import attr
 from examples.service.hello_service import HelloService
 from interface.services.examples.hello.ihello_service import HelloServiceClient
 from pyon.net.endpoint import RPCServer
 from pyon.util.async import spawn
+import unittest
+from pyon.ion.exchange import ExchangeManager, ION_ROOT_XS
+from mock import Mock, sentinel
+from pyon.net.transport import BaseTransport
+
+@attr('UNIT', group='exchange')
+class TestExchangeObjects(IonUnitTestCase):
+    def setUp(self):
+        self.ex_manager = ExchangeManager(Mock())
+        self.ex_manager._transport  = Mock(BaseTransport)
+        self.ex_manager._client     = Mock()
+
+    def test_exchange_by_name(self):
+        # defaults: Root XS, no XNs
+        self.assertIn(ION_ROOT_XS, self.ex_manager.xs_by_name)
+        self.assertIn(self.ex_manager.default_xs, self.ex_manager.xs_by_name.itervalues())
+        self.assertEquals(len(self.ex_manager.xn_by_name), 0)
+
+        # create another XS
+        xs = self.ex_manager.create_xs('exchange')
+        self.assertIn('exchange', self.ex_manager.xs_by_name)
+        self.assertIn(xs, self.ex_manager.xs_by_name.values())
+        self.assertEquals(len(self.ex_manager.xn_by_name), 0)
+
+        # now create some XNs underneath default exchange
+        xn1 = self.ex_manager.create_xn(self.ex_manager.default_xs, 'xn1')
+        self.assertIn('xn1', self.ex_manager.xn_by_name)
+        self.assertIn(xn1, self.ex_manager.xn_by_name.values())
+        self.assertEquals(xn1, self.ex_manager.xn_by_name['xn1'])
+
+        self.assertEquals({ION_ROOT_XS:[xn1]}, self.ex_manager.xn_by_xs)
+
+        xn2 = self.ex_manager.create_xn(self.ex_manager.default_xs, 'xn2')
+        self.assertIn('xn2', self.ex_manager.xn_by_name)
+        self.assertIn(xn2, self.ex_manager.xn_by_xs[ION_ROOT_XS])
+
+        # create one under our second xn3
+        xn3 = self.ex_manager.create_xn(xs, 'xn3')
+        self.assertIn('xn3', self.ex_manager.xn_by_name)
+        self.assertIn(xn3, self.ex_manager.xn_by_xs['exchange'])
+        self.assertNotIn(xn3, self.ex_manager.xn_by_xs[ION_ROOT_XS])
 
 @attr('INT', group='exchange')
-class TestExchangeObjects(IonIntegrationTestCase):
+class TestExchangeObjectsInt(IonIntegrationTestCase):
     def setUp(self):
         self._start_container()
 

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+import unittest
+
+__author__ = 'Dave Foster <dfoster@asascience.com>'
+
+from pyon.util.int_test import IonIntegrationTestCase
+from nose.plugins.attrib import attr
+from examples.service.hello_service import HelloService
+from interface.services.examples.hello.ihello_service import HelloServiceClient
+from pyon.net.endpoint import RPCServer
+from pyon.util.async import spawn
+
+@attr('INT', group='exchange')
+class TestExchangeObjects(IonIntegrationTestCase):
+    def setUp(self):
+        self._start_container()
+
+    def test_rpc_with_xn(self):
+        # get an xn to use for send/recv
+        xn = self.container.ex_manager.create_xn(self.container.ex_manager.default_xs, 'hello', auto_delete=False)
+
+        # create an RPCServer for a hello service
+        hs = HelloService()
+        rpcs = RPCServer(from_name=xn, service=hs)
+
+        # spawn the listener, kill on test exit (success/fail/error should cover?)
+        gl_listen = spawn(rpcs.listen)
+        self.addCleanup(gl_listen.kill)
+
+        # ok, now create a client using same xn
+        hsc = HelloServiceClient(to_name=xn)
+
+        # try to message it!
+        ret = hsc.hello('hi there')
+
+        # did we get back what we expected?
+        self.assertEquals(ret, 'BACK:hi there')
+
+    def test_pubsub_with_xp(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_exchange_by_name(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_create_xs(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_create_xp(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_create_xn(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_delete_xs(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_delete_xp(self):
+        raise unittest.SkipTest("not done yet")
+
+    def test_delete_xn(self):
+        raise unittest.SkipTest("not done yet")

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from pyon.core.bootstrap import get_sys_name
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 
@@ -13,7 +12,9 @@ from pyon.util.async import spawn
 import unittest
 from pyon.ion.exchange import ExchangeManager, ION_ROOT_XS, ExchangeNameProcess, ExchangeSpace, ExchangePoint, ExchangeNameService, ExchangeName, ExchangeNameQueue
 from mock import Mock, sentinel
-from pyon.net.transport import BaseTransport
+from pyon.net.transport import BaseTransport, TransportError, AMQPTransport
+from pyon.core.bootstrap import get_sys_name
+from pyon.net.channel import RecvChannel
 
 @attr('UNIT', group='exchange')
 class TestExchangeObjects(IonUnitTestCase):
@@ -280,23 +281,127 @@ class TestExchangeObjectsInt(IonIntegrationTestCase):
     def test_pubsub_with_xp(self):
         raise unittest.SkipTest("not done yet")
 
-    def test_exchange_by_name(self):
-        raise unittest.SkipTest("not done yet")
+@attr('INT', group='exchange')
+class TestExchangeObjectsCreateDelete(IonIntegrationTestCase):
+    """
+    Tests creation and deletion of things on the broker.
+
+    We're intentionally trying to declare things and have them blow up and catch them.
+    This could very well leave things in a bad state on the broker, but the tests should
+    still be able to run again and again.
+
+    We need a better way of inspecting the broker.
+    https://github.com/auser/alice is a good option, but looks like we need to use a community fork
+    on github to make it work on a modern rabbit: https://github.com/paukul/alice/commit/3c984a8b88d00f61a65516b16a66d5174782820b
+    """
+    def setUp(self):
+        self._start_container()
 
     def test_create_xs(self):
-        raise unittest.SkipTest("not done yet")
+        xs = self.container.ex_manager.create_xs('test_xs')
+        self.addCleanup(xs.delete)
+
+        # TEST SPECIFIC: make sure we can't declare exchange (already exists with diff params)
+        # get a RecvChannel, mess with the settings to purposely mismatch
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xs._xs_auto_delete
+
+        self.assertRaises(TransportError, ch._declare_exchange, xs.exchange)
 
     def test_create_xp(self):
-        raise unittest.SkipTest("not done yet")
+        xp = self.container.ex_manager.create_xp('test_xp')
+        self.addCleanup(xp.delete)
+
+        # TEST SPECIFIC: make sure we can't declare exchange (already exists with diff params)
+        # get a RecvChannel, mess with the settings to purposely mismatch
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xp._xs._xs_auto_delete
+
+        self.assertRaises(TransportError, ch._declare_exchange, xp.exchange)
 
     def test_create_xn(self):
-        raise unittest.SkipTest("not done yet")
+        xn = self.container.ex_manager.create_xn_service('test_service')
+        self.addCleanup(xn.delete)
+
+        # TEST SPECIFIC: make sure we can't declare queue (already exists with diff params)
+        # get a RecvChannel, mess with the settings to purposely mismatch
+        ch = self.container.node.channel(RecvChannel)
+        ch._queue_auto_delete = not xn._xn_auto_delete
+
+        # must set recv_name (declare queue demands it)
+        ch._recv_name = xn
+
+        self.assertRaises(TransportError, ch._declare_queue, xn.queue)
 
     def test_delete_xs(self):
-        raise unittest.SkipTest("not done yet")
+        # we get interesting here.  we have to create or xs, try to declare again to prove it is there,
+        # then delete, then declare to prove we CAN create, then make sure to clean it up.  whew.
+        xs = self.container.ex_manager.create_xs('test_xs')
+
+        # prove XS is declared already (can't declare the same named one with diff params)
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xs._xs_auto_delete
+
+        self.assertRaises(TransportError, ch._declare_exchange, xs.exchange)
+
+        # now let's delete via ex manager
+        self.container.ex_manager.delete_xs(xs)
+
+        # grab another channel and declare (should work fine this time)
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xs._xs_auto_delete
+
+        ch._declare_exchange(xs.exchange)
+
+        # cool, now cleanup (we don't expose this via Channel)
+        at = AMQPTransport.get_instance()
+        at.delete_exchange_impl(ch._amq_chan, xs.exchange)
 
     def test_delete_xp(self):
-        raise unittest.SkipTest("not done yet")
+        # same as test_delete_xs
+        xp = self.container.ex_manager.create_xp('test_xp')
+
+        # prove XS is declared already (can't declare the same named one with diff params)
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xp._xs._xs_auto_delete
+
+        self.assertRaises(TransportError, ch._declare_exchange, xp.exchange)
+
+        # now let's delete via ex manager
+        self.container.ex_manager.delete_xp(xp)
+
+        # grab another channel and declare (should work fine this time)
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xp._xs._xs_auto_delete
+
+        ch._declare_exchange(xp.exchange)
+
+        # cool, now cleanup (we don't expose this via Channel)
+        at = AMQPTransport.get_instance()
+        at.delete_exchange_impl(ch._amq_chan, xp.exchange)
 
     def test_delete_xn(self):
-        raise unittest.SkipTest("not done yet")
+        # same as the other deletes except with queues instead
+
+        xn = self.container.ex_manager.create_service_xn('test_service')
+
+        # prove queue is declared already (can't declare the same named one with diff params)
+        ch = self.container.node.channel(RecvChannel)
+        ch._queue_auto_delete = not xn._xn_auto_delete
+
+        # must set recv_name
+        ch._recv_name = xn
+        self.assertRaises(TransportError, ch._declare_queue, xn.queue)
+
+        # now let's delete via ex manager
+        self.container.ex_manager.delete_xn(xn)
+
+        # grab another channel and declare (should work fine this time)
+        ch = self.container.node.channel(RecvChannel)
+        ch._exchange_auto_delete = not xp._xs._xs_auto_delete
+
+        ch._declare_exchange(xp.exchange)
+
+        # cool, now cleanup (we don't expose this via Channel)
+        at = AMQPTransport.get_instance()
+        at.delete_exchange_impl(ch._amq_chan, xp.exchange)

--- a/pyon/net/channel.py
+++ b/pyon/net/channel.py
@@ -364,7 +364,10 @@ class RecvChannel(BaseChannel):
 
         # only reset the name if it was passed in
         if name != self._recv_name:
-            self._recv_name = NamePair(exchange, queue, binding)
+            if isinstance(name, NamePair):
+                self._recv_name = name
+            else:
+                self._recv_name = NamePair(exchange, queue, binding)
 
         self._declare_exchange(exchange)
         queue   = self._declare_queue(queue)

--- a/pyon/net/channel.py
+++ b/pyon/net/channel.py
@@ -343,7 +343,7 @@ class RecvChannel(BaseChannel):
         - _declare_queue
         - _bind
 
-        Name must be a tuple of (xp, queue). If queue is None, the broker will generate a name e.g. "amq-RANDOMSTUFF".
+        Name must be a NameTrio. If queue is None, the broker will generate a name e.g. "amq-RANDOMSTUFF".
         Binding may be left none and will use the queue name by default.
 
         Sets the _setup_listener_called internal flag, so if this method is called multiple times, such as in the case

--- a/pyon/net/channel.py
+++ b/pyon/net/channel.py
@@ -482,7 +482,7 @@ class RecvChannel(BaseChannel):
     def _declare_queue(self, queue):
 
         # prepend xp name in the queue for anti-clobbering
-        if queue:
+        if queue and not self._recv_name.exchange in queue:
             queue = ".".join([self._recv_name.exchange, queue])
             log.debug('Auto-prepending exchange to queue name for anti-clobbering: %s', queue)
 

--- a/pyon/net/channel.py
+++ b/pyon/net/channel.py
@@ -43,7 +43,7 @@ from pika import BasicProperties
 from gevent import queue as gqueue
 from contextlib import contextmanager
 from gevent.event import AsyncResult
-from pyon.net.transport import AMQPTransport, NamePair
+from pyon.net.transport import AMQPTransport, NameTrio
 
 class ChannelError(StandardError):
     """
@@ -269,7 +269,7 @@ class SendChannel(BaseChannel):
     def connect(self, name):
         """
         Sets up this channel to send to a name.
-        @param  name    The name this channel should send to. Should be a NamePair.
+        @param  name    The name this channel should send to. Should be a NameTrio.
         """
         log.debug("SendChannel.connect: %s", name)
 
@@ -364,10 +364,10 @@ class RecvChannel(BaseChannel):
 
         # only reset the name if it was passed in
         if name != self._recv_name:
-            if isinstance(name, NamePair):
+            if isinstance(name, NameTrio):
                 self._recv_name = name
             else:
-                self._recv_name = NamePair(exchange, queue, binding)
+                self._recv_name = NameTrio(exchange, queue, binding)
 
         self._declare_exchange(exchange)
         queue   = self._declare_queue(queue)
@@ -501,7 +501,7 @@ class RecvChannel(BaseChannel):
 
         # save the new recv_name if our queue name differs (anon queue via '', or exchange prefixing)
         if queue_name != self._recv_name.queue:
-            self._recv_name = NamePair(self._recv_name.exchange, queue_name, self._recv_name.binding)
+            self._recv_name = NameTrio(self._recv_name.exchange, queue_name, self._recv_name.binding)
 
         return self._recv_name.queue
 
@@ -633,7 +633,7 @@ class ServerChannel(ListenChannel):
         pass
 
     def _create_accepted_channel(self, amq_chan, msg):
-        send_name = NamePair(tuple(msg[1].get('reply-to').split(',')))    # @TODO: stringify is not the best
+        send_name = NameTrio(tuple(msg[1].get('reply-to').split(',')))    # @TODO: stringify is not the best
         ch = self.BidirAcceptChannel()
         ch.attach_underlying_channel(amq_chan)
         ch.connect(send_name)

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -10,6 +10,7 @@ from pyon.net.channel import ChannelError, ChannelClosedError, BaseChannel, Publ
 from pyon.core.interceptor.interceptor import Invocation, process_interceptors
 from pyon.util.async import spawn, switch
 from pyon.util.log import log
+from pyon.net.transport import NamePair
 
 from gevent import event, coros
 from gevent.timeout import Timeout
@@ -231,29 +232,21 @@ class BaseEndpoint(object):
     """
     endpoint_unit_type = EndpointUnit
     channel_type = BidirClientChannel
-    name = None
     node = None     # connection to the broker, basically
 
     # Endpoints
     # TODO: Make weakref or replace entirely
     endpoint_by_name = {}
 
-    def __init__(self, node=None, name=None):
-        """
-        name can be a to address or a from address in the derived ListeningBaseEndpoint. Either a string
-        or a 2-tuple of (exchange, name).
-        """
-
-        if not isinstance(name, tuple):
-            name = (bootstrap.get_sys_name(), name)
+    def __init__(self, node=None):
 
         self.node = node
-        self.name = name
 
-        if name in self.endpoint_by_name:
-            self.endpoint_by_name[name].append(self)
-        else:
-            self.endpoint_by_name[name] = [self]
+#        # @TODO: MOVE THIS
+#        if name in self.endpoint_by_name:
+#            self.endpoint_by_name[name].append(self)
+#        else:
+#            self.endpoint_by_name[name] = [self]
 
     def _get_container_instance(self):
         """
@@ -288,17 +281,8 @@ class BaseEndpoint(object):
         if existing_channel:
             ch = existing_channel
         else:
-            name = to_name or self.name
-            assert name
-            if not isinstance(name, tuple):
-                name = (bootstrap.get_sys_name(), name)
-
             self._ensure_node()
             ch = self.node.channel(self.channel_type)
-
-            # @TODO: bla
-            if hasattr(ch, 'connect'):
-                ch.connect(name)
 
         e = self.endpoint_unit_type(**kwargs)
         e.attach_channel(ch)
@@ -310,6 +294,31 @@ class BaseEndpoint(object):
         To be defined by derived classes. Cleanup any resources here, such as channels being open.
         """
         pass
+
+class SendingBaseEndpoint(BaseEndpoint):
+    def __init__(self, node=None, to_name=None, name=None):
+        BaseEndpoint.__init__(self, node=node)
+
+        if name:
+            log.warn("SendingBaseEndpoint: name param is deprecated, please use to_name instead")
+        self._send_name = to_name or name
+
+        # ensure NamePair
+        if not isinstance(self._send_name, NamePair):
+            self._send_name = NamePair(bootstrap.get_sys_name(), self._send_name)   # if send_name is a tuple it takes precedence
+
+    def create_endpoint(self, to_name=None, existing_channel=None, **kwargs):
+        e = BaseEndpoint.create_endpoint(self, to_name=to_name, existing_channel=existing_channel, **kwargs)
+
+        name = to_name or self._send_name
+        assert name
+
+        # ensure NamePair
+        if not isinstance(name, NamePair):
+            name = NamePair(bootstrap.get_sys_name(), name)     # if name is a tuple it takes precedence
+
+        e.channel.connect(name)
+        return e
 
 def log_message(recv, msg, headers, delivery_tag=None):
     """
@@ -325,8 +334,17 @@ class ListeningBaseEndpoint(BaseEndpoint):
     """
     channel_type = ListenChannel
 
-    def __init__(self, node=None, name=None, binding=None):
-        BaseEndpoint.__init__(self, node=node, name=name)
+    def __init__(self, node=None, name=None, from_name=None, binding=None):
+        BaseEndpoint.__init__(self, node=node)
+
+        if name:
+            log.warn("ListeningBaseEndpoint: name param is deprecated, please use from_name instead")
+        self._recv_name = from_name or name
+
+        # ensure NamePair
+        if not isinstance(self._recv_name, NamePair):
+            self._recv_name = NamePair(bootstrap.get_sys_name(), self._recv_name)   # if _recv_name is tuple it takes precedence
+
         self._ready_event = event.Event()
         self._binding = binding
 
@@ -343,24 +361,24 @@ class ListeningBaseEndpoint(BaseEndpoint):
     def listen(self, binding=None):
         log.debug("LEF.listen: binding %s", binding)
 
-        binding = binding or self._binding or self.name[1]
+        binding = binding or self._binding or self._recv_name.queue
 
         self._ensure_node()
         self._chan = self.node.channel(self.channel_type)
-        self._setup_listener(self.name, binding=binding)
+        self._setup_listener(self._recv_name, binding=binding)
         self._chan.start_consume()
 
         # notify any listeners of our readiness
         self._ready_event.set()
 
         while True:
-            log.debug("LEF: %s blocking, waiting for a message" % str(self.name))
+            log.debug("LEF: %s blocking, waiting for a message" % str(self._recv_name))
             try:
                 newchan = self._chan.accept()
                 msg, headers, delivery_tag = newchan.recv()
 
-                log.debug("LEF %s received message %s, headers %s, delivery_tag %s", self.name, msg, headers, delivery_tag)
-                log_message(self.name, msg, headers, delivery_tag)
+                log.debug("LEF %s received message %s, headers %s, delivery_tag %s", self._recv_name, msg, headers, delivery_tag)
+                log_message(self._recv_name, msg, headers, delivery_tag)
 
             except ChannelClosedError as ex:
                 log.debug('Channel was closed during LEF.listen')
@@ -387,7 +405,7 @@ class ListeningBaseEndpoint(BaseEndpoint):
 class PublisherEndpointUnit(EndpointUnit):
     pass
 
-class Publisher(BaseEndpoint):
+class Publisher(SendingBaseEndpoint):
     """
     Simple publisher sends out broadcast messages.
     """
@@ -397,7 +415,7 @@ class Publisher(BaseEndpoint):
 
     def __init__(self, **kwargs):
         self._pub_ep = None
-        BaseEndpoint.__init__(self, **kwargs)
+        SendingBaseEndpoint.__init__(self, **kwargs)
 
     def publish(self, msg, to_name=None):
 
@@ -405,7 +423,7 @@ class Publisher(BaseEndpoint):
         if not to_name:
             # @TODO: needs thread safety
             if not self._pub_ep:
-                self._pub_ep = self.create_endpoint(self.name)
+                self._pub_ep = self.create_endpoint(self._send_name)
             ep = self._pub_ep
         else:
             ep = self.create_endpoint(to_name)
@@ -488,7 +506,7 @@ class RequestEndpointUnit(BidirectionalEndpointUnit):
         log.debug("RequestEndpointUnit.send")
 
         if not self._recv_greenlet:
-            self.channel.setup_listener((self.channel._send_name[0], None)) # @TODO: not quite right..
+            self.channel.setup_listener(NamePair(self.channel._send_name.exchange)) # anon queue
             self.channel.start_consume()
             self.spawn_listener()
 
@@ -512,11 +530,11 @@ class RequestEndpointUnit(BidirectionalEndpointUnit):
         headers = BidirectionalEndpointUnit._build_header(self, raw_msg)
         headers['performative'] = 'request'
         if self.channel and self.channel._send_name and isinstance(self.channel._send_name, tuple):
-            headers['receiver'] = "%s,%s" % self.channel._send_name   # @TODO updated by XN work, should be FQ?
+            headers['receiver'] = "%s,%s" % (self.channel._send_name.exchange, self.channel._send_name.queue)   # @TODO correct?
 
         return headers
 
-class RequestResponseClient(BaseEndpoint):
+class RequestResponseClient(SendingBaseEndpoint):
     """
     Sends a request, waits for a response.
     """
@@ -524,7 +542,7 @@ class RequestResponseClient(BaseEndpoint):
 
     def request(self, msg, headers=None):
         log.debug("RequestResponseClient.request: %s, headers: %s", msg, headers)
-        e = self.create_endpoint(self.name)
+        e = self.create_endpoint(self._send_name)
         try:
             retval, headers = e.send(msg, headers=headers)
         finally:
@@ -543,7 +561,7 @@ class ResponseEndpointUnit(BidirectionalListeningEndpointUnit):
         headers = BidirectionalListeningEndpointUnit._build_header(self, raw_msg)
         headers['performative'] = 'inform-result'                       # overriden by response pattern, feels wrong
         if self.channel and self.channel._send_name and isinstance(self.channel._send_name, tuple):
-            headers['receiver'] = "%s,%s" % self.channel._send_name     # @TODO updated by XN work, should be FQ?
+            headers['receiver'] = "%s,%s" % (self.channel._send_name.exchange, self.channel._send_name.queue)       # @TODO: correct?
         headers['language']     = 'ion-r2'
         headers['encoding']     = 'msgpack'
         headers['format']       = raw_msg.__class__.__name__    # hmm
@@ -851,8 +869,8 @@ class ProcessRPCRequestEndpointUnit(RPCRequestEndpointUnit):
 
         if hasattr(self._process,'process_type' ):
             header.update({'sender-type'  : self._process.process_type or 'unknown-process-type' })
-            if self._process.process_type == 'service':     # @TODO updated by XN work
-                header.update({ 'sender-service' : "%s,%s" % ( self.channel._send_name[0],self._process.name) })
+            if self._process.process_type == 'service':
+                header.update({ 'sender-service' : "%s,%s" % ( self.channel._send_name.exchange,self._process.name) })
 
         # use context to set security attributes forward
         if isinstance(context, dict):
@@ -941,8 +959,8 @@ class ProcessRPCResponseEndpointUnit(RPCResponseEndpointUnit):
 
         if hasattr(self._process,'process_type' ):
             header.update({'sender-type'  : self._process.process_type or 'unknown-process-type' })
-            if self._process.process_type == 'service':     # @TODO updated by XN work
-                header.update({ 'sender-service' : "%s,%s" % ( self.channel._send_name[0],self._process.name) })
+            if self._process.process_type == 'service':
+                header.update({ 'sender-service' : "%s,%s" % ( self.channel._send_name.exchange,self._process.name) })
 
         # use context to set security attributes forward
         if isinstance(context, dict):

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -396,8 +396,12 @@ class ListeningBaseEndpoint(BaseEndpoint):
             kwargs.update({'transport':self._recv_name})
         self._chan = self.node.channel(self.channel_type, **kwargs)
 
-        # @TODO: this duplicates things a little that may be done by an ExchangeObject
-        self._setup_listener(self._recv_name, binding=binding)
+        # @TODO this does not feel right
+        if isinstance(self._recv_name, BaseTransport):
+            self._recv_name.setup_listener(binding, self._setup_listener)
+            self._chan._recv_name = self._recv_name
+        else:
+            self._setup_listener(self._recv_name, binding=binding)
         self._chan.start_consume()
 
         # notify any listeners of our readiness

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -10,7 +10,7 @@ from pyon.net.channel import ChannelError, ChannelClosedError, BaseChannel, Publ
 from pyon.core.interceptor.interceptor import Invocation, process_interceptors
 from pyon.util.async import spawn, switch
 from pyon.util.log import log
-from pyon.net.transport import NamePair, BaseTransport
+from pyon.net.transport import NameTrio, BaseTransport
 
 from gevent import event, coros
 from gevent.timeout import Timeout
@@ -311,9 +311,9 @@ class SendingBaseEndpoint(BaseEndpoint):
             log.warn("SendingBaseEndpoint: name param is deprecated, please use to_name instead")
         self._send_name = to_name or name
 
-        # ensure NamePair
-        if not isinstance(self._send_name, NamePair):
-            self._send_name = NamePair(bootstrap.get_sys_name(), self._send_name)   # if send_name is a tuple it takes precedence
+        # ensure NameTrio
+        if not isinstance(self._send_name, NameTrio):
+            self._send_name = NameTrio(bootstrap.get_sys_name(), self._send_name)   # if send_name is a tuple it takes precedence
 
     def create_endpoint(self, to_name=None, existing_channel=None, **kwargs):
         e = BaseEndpoint.create_endpoint(self, to_name=to_name, existing_channel=existing_channel, **kwargs)
@@ -321,9 +321,9 @@ class SendingBaseEndpoint(BaseEndpoint):
         name = to_name or self._send_name
         assert name
 
-        # ensure NamePair
-        if not isinstance(name, NamePair):
-            name = NamePair(bootstrap.get_sys_name(), name)     # if name is a tuple it takes precedence
+        # ensure NameTrio
+        if not isinstance(name, NameTrio):
+            name = NameTrio(bootstrap.get_sys_name(), name)     # if name is a tuple it takes precedence
 
         e.channel.connect(name)
         return e
@@ -359,9 +359,9 @@ class ListeningBaseEndpoint(BaseEndpoint):
             log.warn("ListeningBaseEndpoint: name param is deprecated, please use from_name instead")
         self._recv_name = from_name or name
 
-        # ensure NamePair
-        if not isinstance(self._recv_name, NamePair):
-            self._recv_name = NamePair(bootstrap.get_sys_name(), self._recv_name, binding)   # if _recv_name is tuple it takes precedence
+        # ensure NameTrio
+        if not isinstance(self._recv_name, NameTrio):
+            self._recv_name = NameTrio(bootstrap.get_sys_name(), self._recv_name, binding)   # if _recv_name is tuple it takes precedence
 
         self._ready_event = event.Event()
         self._binding = binding
@@ -542,7 +542,7 @@ class RequestEndpointUnit(BidirectionalEndpointUnit):
         log.debug("RequestEndpointUnit.send")
 
         if not self._recv_greenlet:
-            self.channel.setup_listener(NamePair(self.channel._send_name.exchange)) # anon queue
+            self.channel.setup_listener(NameTrio(self.channel._send_name.exchange)) # anon queue
             self.channel.start_consume()
             self.spawn_listener()
 

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -311,28 +311,6 @@ class BaseEndpoint(object):
         """
         pass
 
-class ExchangeManagementEndpointUnit(EndpointUnit):
-    def create_xs(self, name):
-        pass
-
-class ExchangeManagement(BaseEndpoint):
-    endpoint_unit_type = ExchangeManagementEndpointUnit
-    channel_type = BaseChannel
-
-    def __init__(self, **kwargs):
-        self._pub_ep = None
-        BaseEndpoint.__init__(self, **kwargs)
-
-    def create_xs(self, name):
-        if not self._exchange_ep:
-            self._exchange_ep = self.create_endpoint(self.name)
-
-        self._exchange_ep.create_xs(name)
-
-    def close(self):
-        if self._exchange_ep:
-            self._exchange_ep.close()
-
 def log_message(recv, msg, headers, delivery_tag=None):
     """
     Utility function to print an legible comprehensive summary of a received message.

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -361,7 +361,7 @@ class ListeningBaseEndpoint(BaseEndpoint):
 
         # ensure NamePair
         if not isinstance(self._recv_name, NamePair):
-            self._recv_name = NamePair(bootstrap.get_sys_name(), self._recv_name)   # if _recv_name is tuple it takes precedence
+            self._recv_name = NamePair(bootstrap.get_sys_name(), self._recv_name, binding)   # if _recv_name is tuple it takes precedence
 
         self._ready_event = event.Event()
         self._binding = binding
@@ -388,7 +388,7 @@ class ListeningBaseEndpoint(BaseEndpoint):
     def listen(self, binding=None):
         log.debug("LEF.listen: binding %s", binding)
 
-        binding = binding or self._binding or self._recv_name.queue
+        binding = binding or self._binding or self._recv_name.binding
 
         self._ensure_node()
         kwargs = {}

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -391,7 +391,12 @@ class ListeningBaseEndpoint(BaseEndpoint):
         binding = binding or self._binding or self._recv_name.queue
 
         self._ensure_node()
-        self._chan = self.node.channel(self.channel_type)
+        kwargs = {}
+        if isinstance(self._recv_name, BaseTransport):
+            kwargs.update({'transport':self._recv_name})
+        self._chan = self.node.channel(self.channel_type, **kwargs)
+
+        # @TODO: this duplicates things a little that may be done by an ExchangeObject
         self._setup_listener(self._recv_name, binding=binding)
         self._chan.start_consume()
 

--- a/pyon/net/messaging.py
+++ b/pyon/net/messaging.py
@@ -44,16 +44,16 @@ class NodeB(amqp.Node):
         self.running = 1
         self.ready.set()
 
-    def _new_channel(self, ch_type):
+    def _new_channel(self, ch_type, **kwargs):
         """
         Creates a pyon Channel based on the passed in type, and activates it for use.
         """
-        chan = ch_type()
+        chan = ch_type(**kwargs)
         amq_chan = blocking_cb(self.client.channel, 'on_open_callback')
         chan.on_channel_open(amq_chan)
         return chan
 
-    def channel(self, ch_type):
+    def channel(self, ch_type, **kwargs):
         """
         Creates a Channel object with an underlying transport callback and returns it.
 
@@ -71,12 +71,12 @@ class NodeB(amqp.Node):
                     self._pool_map[ch.get_channel_id()] = chid
                 else:
                     log.debug("BidirClientChannel requested, no pool items available, creating new (%d)", chid)
-                    ch = self._new_channel(ch_type)
+                    ch = self._new_channel(ch_type, **kwargs)
                     ch.set_close_callback(self.on_channel_request_close)
                     self._bidir_pool[chid] = ch
                     self._pool_map[ch.get_channel_id()] = chid
             else:
-                ch = self._new_channel(ch_type)
+                ch = self._new_channel(ch_type, **kwargs)
             assert ch
 
         return ch

--- a/pyon/net/test/test_channel.py
+++ b/pyon/net/test/test_channel.py
@@ -26,12 +26,12 @@ class TestBaseChannel(PyonTestCase):
     def test_declare_exchange_point(self):
         # make sure no xp param results in assertion
         ch = BaseChannel()
-        self.assertRaises(AssertionError, ch._declare_exchange_point, None)
+        self.assertRaises(AssertionError, ch._declare_exchange, None)
 
         ch._transport = Mock()
         ch._amq_chan = Mock()
 
-        ch._declare_exchange_point('hello')
+        ch._declare_exchange('hello')
         self.assertTrue(ch._transport.declare_exchange_impl.called)
         self.assertIn(ch._amq_chan,     ch._transport.declare_exchange_impl.call_args[0])
         self.assertIn('hello',          ch._transport.declare_exchange_impl.call_args[0])
@@ -147,7 +147,7 @@ class TestRecvChannel(PyonTestCase):
         self.ch = RecvChannel()
 
     def test_setup_listener(self):
-        # sub in mocks for _declare_exchange_point, _declare_queue, _bind
+        # sub in mocks for _declare_exchange, _declare_queue, _bind
         mxp = Mock()
         mdq = Mock()
         mdq.return_value = sentinel.anon_queue
@@ -155,7 +155,7 @@ class TestRecvChannel(PyonTestCase):
 
         def create_channel():
             ch = RecvChannel()
-            ch._declare_exchange_point = mxp
+            ch._declare_exchange = mxp
             ch._declare_queue = mdq
             ch._bind = mb
             return ch
@@ -489,7 +489,7 @@ class TestPublisherChannel(PyonTestCase):
     def test_send(self, mocksendchannel):
         depmock = Mock()
         pubchan = PublisherChannel()
-        pubchan._declare_exchange_point = depmock
+        pubchan._declare_exchange = depmock
 
         pubchan._send_name = NamePair(sentinel.xp, sentinel.routing_key)
 

--- a/pyon/net/test/test_channel.py
+++ b/pyon/net/test/test_channel.py
@@ -11,6 +11,7 @@ from mock import Mock, sentinel, patch
 from pika import channel as pchannel
 from pika import BasicProperties
 from nose.plugins.attrib import attr
+from pyon.net.transport import NamePair, BaseTransport
 
 @attr('UNIT')
 class TestBaseChannel(PyonTestCase):
@@ -27,23 +28,16 @@ class TestBaseChannel(PyonTestCase):
         ch = BaseChannel()
         self.assertRaises(AssertionError, ch._declare_exchange_point, None)
 
-        # test it for real
-        ac = Mock(spec=pchannel.Channel)
-        def cbparam(*args, **kwargs):
-            cbkwarg = kwargs.get('callback')
-            cbkwarg(kwargs.get('exchange'))
-            return kwargs.get('exchange')
-        ac.exchange_declare.side_effect = cbparam
-
-        ch._amq_chan = ac
+        ch._transport = Mock()
+        ch._amq_chan = Mock()
 
         ch._declare_exchange_point('hello')
-        self.assertTrue(ac.exchange_declare.called)
-        self.assertIn('exchange',       ac.exchange_declare.call_args[1])
-        self.assertIn('type',           ac.exchange_declare.call_args[1])
-        self.assertIn('durable',        ac.exchange_declare.call_args[1])
-        self.assertIn('auto_delete',    ac.exchange_declare.call_args[1])
-        self.assertIn('hello',          ac.exchange_declare.call_args[1].itervalues())
+        self.assertTrue(ch._transport.declare_exchange_impl.called)
+        self.assertIn(ch._amq_chan,     ch._transport.declare_exchange_impl.call_args[0])
+        self.assertIn('hello',          ch._transport.declare_exchange_impl.call_args[0])
+        self.assertIn('exchange_type',  ch._transport.declare_exchange_impl.call_args[1])
+        self.assertIn('durable',        ch._transport.declare_exchange_impl.call_args[1])
+        self.assertIn('auto_delete',    ch._transport.declare_exchange_impl.call_args[1])
 
     def test_attach_underlying_channel(self):
         ch = BaseChannel()
@@ -102,24 +96,28 @@ class TestSendChannel(PyonTestCase):
         self.ch = SendChannel()
 
     def test_connect(self):
-        self.ch.connect(('xp', 'key'))
-        self.assertEquals(self.ch._send_name, ('xp', 'key'))
+        self.ch.connect(NamePair('xp', 'key'))
+        self.assertTrue(hasattr(self.ch._send_name, 'exchange'))
+        self.assertTrue(hasattr(self.ch._send_name, 'queue'))
+        self.assertEquals(self.ch._send_name.exchange, 'xp')
+        self.assertEquals(self.ch._send_name.queue, 'key')
         self.assertEquals(self.ch._exchange, 'xp')
 
     def test_send(self):
         _sendmock = Mock()
         self.ch._send = _sendmock
-        self.ch.connect(('xp', 'key'))
+        np = NamePair('xp', 'key')
+        self.ch.connect(np)
 
         self.ch.send('data', {'header':sentinel.headervalue})
-        _sendmock.assert_called_once_with(('xp', 'key'), 'data', headers={'header':sentinel.headervalue})
+        _sendmock.assert_called_once_with(np, 'data', headers={'header':sentinel.headervalue})
 
     def test__send(self):
         ac = Mock(pchannel.Channel)
         self.ch._amq_chan = ac
 
         # test sending in params
-        self.ch._send(('xp', 'namen'), 'daten')
+        self.ch._send(NamePair('xp', 'namen'), 'daten')
 
         # get our props
         self.assertTrue(ac.basic_publish.called)
@@ -136,7 +134,7 @@ class TestSendChannel(PyonTestCase):
         self.assertEquals(props.headers, {})
 
         # try another call to _send with a header
-        self.ch._send(('xp', 'namen'), 'daten', headers={'custom':'val'})
+        self.ch._send(NamePair('xp', 'namen'), 'daten', headers={'custom':'val'})
 
         # make sure our property showed up
         props = ac.basic_publish.call_args[1].get('properties')
@@ -167,10 +165,13 @@ class TestRecvChannel(PyonTestCase):
         self.assertFalse(ch._setup_listener_called)
 
         # call setup listener, defining xp, queue, default binding (will get our return value above) becuase there's no meat to _declare_queue
-        ch.setup_listener((sentinel.xp, sentinel.queue))
+        ch.setup_listener(NamePair(sentinel.xp, sentinel.queue))
 
         self.assertTrue(hasattr(ch, '_recv_name'))
-        self.assertEquals(ch._recv_name, (sentinel.xp, sentinel.queue))
+        self.assertTrue(hasattr(ch._recv_name, 'exchange'))
+        self.assertTrue(hasattr(ch._recv_name, 'queue'))
+        self.assertEquals(ch._recv_name.exchange, sentinel.xp)
+        self.assertEquals(ch._recv_name.queue, sentinel.queue)
 
         mxp.assert_called_once_with(sentinel.xp)
         mdq.assert_called_once_with(sentinel.queue)
@@ -180,16 +181,19 @@ class TestRecvChannel(PyonTestCase):
         self.assertTrue(ch._setup_listener_called)
         
         # calling it again does nothing, does not touch anything
-        ch.setup_listener((sentinel.xp2, sentinel.queue2))
+        ch.setup_listener(NamePair(sentinel.xp2, sentinel.queue2))
 
-        self.assertEquals(ch._recv_name, (sentinel.xp, sentinel.queue))
+        self.assertTrue(hasattr(ch._recv_name, 'exchange'))
+        self.assertTrue(hasattr(ch._recv_name, 'queue'))
+        self.assertEquals(ch._recv_name.exchange, sentinel.xp)
+        self.assertEquals(ch._recv_name.queue, sentinel.queue)
         mxp.assert_called_once_with(sentinel.xp)
         mdq.assert_called_once_with(sentinel.queue)
         mb.assert_called_once_with(sentinel.anon_queue)
 
         # call setup listener, passing a custom bind this time
         ch = create_channel()
-        ch.setup_listener((sentinel.xp2, sentinel.queue2), binding=sentinel.binding)
+        ch.setup_listener(NamePair(sentinel.xp2, sentinel.queue2), binding=sentinel.binding)
 
         mxp.assert_called_with(sentinel.xp2)
         mdq.assert_called_with(sentinel.queue2)
@@ -197,7 +201,7 @@ class TestRecvChannel(PyonTestCase):
 
         # call setup_listener, use anonymous queue name and no binding (will get return value we set above)
         ch = create_channel()
-        ch.setup_listener((sentinel.xp3, None))
+        ch.setup_listener(NamePair(sentinel.xp3))
 
         mxp.assert_called_with(sentinel.xp3)
         mdq.assert_called_with(None)
@@ -205,7 +209,7 @@ class TestRecvChannel(PyonTestCase):
 
         # call setup_listener with anon queue name but with binding
         ch = create_channel()
-        ch.setup_listener((sentinel.xp4, None), binding=sentinel.binding2)
+        ch.setup_listener(NamePair(sentinel.xp4), binding=sentinel.binding2)
 
         mxp.assert_called_with(sentinel.xp4)
         mdq.assert_called_with(None)
@@ -215,22 +219,16 @@ class TestRecvChannel(PyonTestCase):
         self.assertRaises(AssertionError, self.ch.destroy_listener)
 
     def test__destroy_queue(self):
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
 
-        def side(*args, **kwargs):
-            cb = kwargs.get('callback')
-            cb()
-
-        ac = Mock(spec=pchannel.Channel)
-        self.ch._amq_chan = ac
-
-        ac.queue_delete.side_effect = side
+        self.ch._transport = Mock(BaseTransport)
+        self.ch._amq_chan = sentinel.amq_chan
 
         self.ch.destroy_listener()
 
-        self.assertTrue(ac.queue_delete.called)
-        self.assertIn('queue', ac.queue_delete.call_args[1])
-        self.assertIn(sentinel.queue, ac.queue_delete.call_args[1].itervalues())
+        self.assertTrue(self.ch._transport.delete_queue_impl.called)
+        self.assertIn('queue', self.ch._transport.delete_queue_impl.call_args[1])
+        self.assertIn(sentinel.queue, self.ch._transport.delete_queue_impl.call_args[1].itervalues())
 
     def test_destroy_listener(self):
         m = Mock()
@@ -243,28 +241,22 @@ class TestRecvChannel(PyonTestCase):
         self.assertRaises(AssertionError, self.ch._destroy_binding)
 
     def test__destroy_binding(self):
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
         self.ch._recv_binding = sentinel.binding
 
-        def side(*args, **kwargs):
-            cb = kwargs.get('callback')
-            cb()
-
-        ac = Mock(spec=pchannel.Channel)
-        self.ch._amq_chan = ac
-
-        ac.queue_unbind.side_effect = side
+        self.ch._transport = Mock(BaseTransport)
+        self.ch._amq_chan = sentinel.amq_chan
 
         self.ch._destroy_binding()
 
-        self.assertTrue(ac.queue_unbind.called)
-        self.assertIn('queue', ac.queue_unbind.call_args[1])
-        self.assertIn('exchange', ac.queue_unbind.call_args[1])
-        self.assertIn('routing_key', ac.queue_unbind.call_args[1])
+        self.assertTrue(self.ch._transport.unbind_impl.called)
+        self.assertIn('queue', self.ch._transport.unbind_impl.call_args[1])
+        self.assertIn('exchange', self.ch._transport.unbind_impl.call_args[1])
+        self.assertIn('binding', self.ch._transport.unbind_impl.call_args[1])
 
-        self.assertIn(sentinel.queue, ac.queue_unbind.call_args[1].itervalues())
-        self.assertIn(sentinel.xp, ac.queue_unbind.call_args[1].itervalues())
-        self.assertIn(sentinel.binding, ac.queue_unbind.call_args[1].itervalues())
+        self.assertIn(sentinel.queue, self.ch._transport.unbind_impl.call_args[1].itervalues())
+        self.assertIn(sentinel.xp, self.ch._transport.unbind_impl.call_args[1].itervalues())
+        self.assertIn(sentinel.binding, self.ch._transport.unbind_impl.call_args[1].itervalues())
 
     def test_start_consume(self):
         ac = Mock(pchannel.Channel)
@@ -273,7 +265,7 @@ class TestRecvChannel(PyonTestCase):
         ac.basic_consume.return_value = sentinel.consumer_tag
 
         # set up recv name for queue
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
 
         self.ch.start_consume()
 
@@ -292,7 +284,7 @@ class TestRecvChannel(PyonTestCase):
         self.ch._amq_chan = ac
 
         # set up recv name for queue
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
 
         self.ch._consumer_tag = sentinel.consumer_tag
         self.ch._queue_auto_delete = True
@@ -382,62 +374,50 @@ class TestRecvChannel(PyonTestCase):
         scmock.assert_called_once_with()
 
     def test_declare_queue(self):
-        # sideeffect that passes a result back (important here)
-        framemock = Mock()
-        framemock.method.queue = sentinel.queue
-
-        def side(*args, **kwargs):
-            cb = kwargs.get('callback')
-            cb(framemock)
-
-        ac = Mock(spec=pchannel.Channel)
-        self.ch._amq_chan = ac
-
-        ac.queue_declare.side_effect = side
+        self.ch._transport = Mock(BaseTransport)
+        self.ch._amq_chan = sentinel.amq_chan
 
         # needs a recv name
-        self.ch._recv_name = (str(sentinel.xp), None)
+        self.ch._recv_name = (NamePair(str(sentinel.xp)))
 
         qd = self.ch._declare_queue(str(sentinel.queue))    # can't join a sentinel
 
-        self.assertTrue(ac.queue_declare.called)
-        self.assertIn('queue', ac.queue_declare.call_args[1])
-        self.assertIn('auto_delete', ac.queue_declare.call_args[1])
-        self.assertIn('durable', ac.queue_declare.call_args[1])
+        self.assertTrue(self.ch._transport.declare_queue_impl.called)
+        self.assertIn('queue', self.ch._transport.declare_queue_impl.call_args[1])
+        self.assertIn('auto_delete', self.ch._transport.declare_queue_impl.call_args[1])
+        self.assertIn('durable', self.ch._transport.declare_queue_impl.call_args[1])
 
         composed = ".".join([str(sentinel.xp), str(sentinel.queue)])
-        self.assertIn(composed, ac.queue_declare.call_args[1].itervalues())
-        self.assertIn(self.ch._queue_auto_delete, ac.queue_declare.call_args[1].itervalues())
-        self.assertIn(self.ch._queue_durable, ac.queue_declare.call_args[1].itervalues())
+        self.assertIn(composed, self.ch._transport.declare_queue_impl.call_args[1].itervalues())
+        self.assertIn(self.ch._queue_auto_delete, self.ch._transport.declare_queue_impl.call_args[1].itervalues())
+        self.assertIn(self.ch._queue_durable, self.ch._transport.declare_queue_impl.call_args[1].itervalues())
 
         # should have set recv_name
-        self.assertEquals(self.ch._recv_name, (str(sentinel.xp), sentinel.queue))
-        self.assertEquals(qd, sentinel.queue)
+        self.assertTrue(hasattr(self.ch._recv_name, 'exchange'))
+        self.assertTrue(hasattr(self.ch._recv_name, 'queue'))
+        self.assertEquals(self.ch._recv_name.exchange, str(sentinel.xp))    # we passed in str() versions
+        self.assertEquals(self.ch._recv_name.queue, self.ch._transport.declare_queue_impl())
+        self.assertEquals(qd, self.ch._transport.declare_queue_impl())
 
     def test__bind_no_name(self):
         self.assertRaises(AssertionError, self.ch._bind, sentinel.binding)
 
     def test__bind(self):
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
 
-        def side(*args, **kwargs):
-            cb = kwargs.get('callback')
-            cb()
-
-        ac = Mock(spec=pchannel.Channel)
-        ac.queue_bind.side_effect = side
-        self.ch._amq_chan = ac
+        self.ch._amq_chan = Mock()
+        self.ch._transport = Mock()
 
         self.ch._bind(sentinel.binding)
 
-        self.assertTrue(ac.queue_bind.called)
-        self.assertIn('queue', ac.queue_bind.call_args[1])
-        self.assertIn('exchange', ac.queue_bind.call_args[1])
-        self.assertIn('routing_key', ac.queue_bind.call_args[1])
+        self.assertTrue(self.ch._transport.bind_impl.called)
+        self.assertIn('queue', self.ch._transport.bind_impl.call_args[1])
+        self.assertIn('exchange', self.ch._transport.bind_impl.call_args[1])
+        self.assertIn('binding', self.ch._transport.bind_impl.call_args[1])
 
-        self.assertIn(sentinel.queue, ac.queue_bind.call_args[1].itervalues())
-        self.assertIn(sentinel.xp, ac.queue_bind.call_args[1].itervalues())
-        self.assertIn(sentinel.binding, ac.queue_bind.call_args[1].itervalues())
+        self.assertIn(sentinel.queue, self.ch._transport.bind_impl.call_args[1].itervalues())
+        self.assertIn(sentinel.xp, self.ch._transport.bind_impl.call_args[1].itervalues())
+        self.assertIn(sentinel.binding, self.ch._transport.bind_impl.call_args[1].itervalues())
 
     def test__on_deliver(self):
         # mock up the method frame (delivery_tag is really only one we care about)
@@ -511,7 +491,7 @@ class TestPublisherChannel(PyonTestCase):
         pubchan = PublisherChannel()
         pubchan._declare_exchange_point = depmock
 
-        pubchan._send_name = (sentinel.xp, sentinel.routing_key)
+        pubchan._send_name = NamePair(sentinel.xp, sentinel.routing_key)
 
         pubchan.send(sentinel.data)
 
@@ -538,7 +518,7 @@ class TestBidirClientChannel(PyonTestCase):
 
     def test__send_with_reply_to(self, mocksendchannel):
 
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
 
         self.ch._send(sentinel.name, sentinel.data, headers={sentinel.header_key: sentinel.header_value})
 
@@ -551,11 +531,11 @@ class TestBidirClientChannel(PyonTestCase):
     def test__send_with_no_reply_to(self, mocksendchannel):
 
         # must set recv_name
-        self.ch._recv_name = (sentinel.xp, sentinel.queue)
+        self.ch._recv_name = NamePair(sentinel.xp, sentinel.queue)
 
         self.ch._send(sentinel.name, sentinel.data)
 
-        mocksendchannel._send.assert_called_with(self.ch, sentinel.name, sentinel.data, headers={'reply-to':"%s,%s" % self.ch._recv_name})
+        mocksendchannel._send.assert_called_with(self.ch, sentinel.name, sentinel.data, headers={'reply-to':"%s,%s" % (sentinel.xp, sentinel.queue)})
 
 @attr('UNIT')
 class TestListenChannel(PyonTestCase):
@@ -603,7 +583,10 @@ class TestServerChannel(PyonTestCase):
 
         self.assertIsInstance(newch, ServerChannel.BidirAcceptChannel)
         self.assertEquals(newch._amq_chan, sentinel.amq_chan)
-        self.assertEquals(newch._send_name, ('one', 'two'))
+        self.assertTrue(hasattr(newch._send_name, 'exchange'))
+        self.assertTrue(hasattr(newch._send_name, 'queue'))
+        self.assertEquals(newch._send_name.exchange, 'one')
+        self.assertEquals(newch._send_name.queue, 'two')
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyon/net/test/test_endpoint.py
+++ b/pyon/net/test/test_endpoint.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from pyon.core.interceptor.interceptor import Invocation
+from pyon.net.transport import NamePair
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
@@ -10,7 +11,7 @@ from zope.interface.interface import Interface
 from pyon.core import exception
 from pyon.net import endpoint
 from pyon.net.channel import BaseChannel, SendChannel, BidirClientChannel, SubscriberChannel, ChannelClosedError, ServerChannel
-from pyon.net.endpoint import EndpointUnit, BaseEndpoint, RPCServer, Subscriber, Publisher, RequestResponseClient, RequestEndpointUnit, RPCRequestEndpointUnit, RPCClient, RPCResponseEndpointUnit, EndpointError
+from pyon.net.endpoint import EndpointUnit, BaseEndpoint, RPCServer, Subscriber, Publisher, RequestResponseClient, RequestEndpointUnit, RPCRequestEndpointUnit, RPCClient, RPCResponseEndpointUnit, EndpointError, SendingBaseEndpoint
 from gevent import event, sleep
 from pyon.net.messaging import NodeB
 from pyon.service.service import BaseService
@@ -104,7 +105,7 @@ class TestEndpointUnit(PyonTestCase):
 class TestBaseEndpoint(PyonTestCase):
     def setUp(self):
         self._node = Mock(spec=NodeB)
-        self._ef = BaseEndpoint(node=self._node, name="EFTest")
+        self._ef = BaseEndpoint(node=self._node)
         self._ch = Mock(spec=SendChannel)
         self._node.channel.return_value = self._ch
 
@@ -113,18 +114,10 @@ class TestBaseEndpoint(PyonTestCase):
 
         # check attrs
         self.assertTrue(hasattr(e, 'channel'))
-        self.assertEquals(self._ch.connect.call_count, 1)
-        self.assertTrue(self._ef.name in self._ch.connect.call_args[0])
 
         # make sure we can shut it down
         e.close()
         self._ch.close.assert_any_call()
-
-    def test_create_endpoint_new_name(self):
-        e = self._ef.create_endpoint(to_name="reroute")
-        self.assertEquals(self._ch.connect.call_count, 1)
-        self.assertTrue("reroute" in self._ch.connect.call_args[0][0])        # @TODO: this is obtuse
-        e.close()
 
     def test_create_endpoint_existing_channel(self):
         ch = Mock(spec=SendChannel)
@@ -154,7 +147,7 @@ class TestBaseEndpoint(PyonTestCase):
         self.assertEquals(e._opt, "stringer")
 
     def test__ensure_node_errors(self):
-        bep = BaseEndpoint(name=sentinel.name)
+        bep = BaseEndpoint()
         gcimock = Mock()
         gcimock.return_value = None
         with patch('pyon.net.endpoint.BaseEndpoint._get_container_instance', gcimock):
@@ -167,18 +160,54 @@ class TestBaseEndpoint(PyonTestCase):
 
     @patch('pyon.net.endpoint.BaseEndpoint._get_container_instance')
     def test__ensure_node(self, gcimock):
-        bep = BaseEndpoint(name=sentinel.name)
+        bep = BaseEndpoint()
         self.assertIsNone(bep.node)
 
         bep._ensure_node()
 
         self.assertEquals(bep.node, gcimock().node)
 
+@attr('UNIT')
+@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
+class TestSendingBaseEndpoint(PyonTestCase):
+    def test_init(self):
+        ep = SendingBaseEndpoint(node=sentinel.node)
+        self.assertEquals(ep.node, sentinel.node)
+        self.assertIsInstance(ep._send_name, NamePair)
+
+    def test_init_with_to_name(self):
+        ep = SendingBaseEndpoint(to_name=(sentinel.xp, sentinel.rkey))
+        self.assertEquals(ep._send_name.exchange, sentinel.xp)
+        self.assertEquals(ep._send_name.queue, sentinel.rkey)
+
+    @patch('pyon.net.endpoint.log')
+    def test_init_with_old_name_gives_warn(self, mocklog):
+        ep = SendingBaseEndpoint(name=(sentinel.xp, sentinel.rkey))
+        self.assertEquals(ep._send_name.exchange, sentinel.xp)
+        self.assertEquals(ep._send_name.queue, sentinel.rkey)
+        self.assertTrue(mocklog.warn.called)
+
+    def test_init_with_to_name_namepair(self):
+        class MyNamePair(NamePair):
+            def __init__(self):
+                self._exchange = sentinel.my_exchange
+                self._queue = sentinel.my_queue
+
+        ep = SendingBaseEndpoint(to_name=MyNamePair())
+        self.assertEquals(ep._send_name.exchange, sentinel.my_exchange)
+        self.assertEquals(ep._send_name.queue, sentinel.my_queue)
+
+    def test_create_endpoint_calls_connect(self):
+        np = NamePair(sentinel.xp, sentinel.queue)
+        ep = SendingBaseEndpoint(node=Mock(spec=NodeB), to_name=np)
+        e = ep.create_endpoint()
+        e.channel.connect.assert_called_once_with(np)
+
 @patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestPublisher(PyonTestCase):
     def setUp(self):
         self._node = Mock(spec=NodeB)
-        self._pub = Publisher(node=self._node, name="testpub")
+        self._pub = Publisher(node=self._node, to_name="testpub")
         self._ch = Mock(spec=SendChannel)
         self._node.channel.return_value = self._ch
 
@@ -219,7 +248,7 @@ class RecvMockMixin(object):
         ch.recv.side_effect = _ret
 
         # need to set a send_name for now
-        ch._send_name = ('', '')
+        ch._send_name = NamePair('', '')
 
         return ch
 
@@ -231,13 +260,13 @@ class TestSubscriber(PyonTestCase, RecvMockMixin):
         self._node = Mock(spec=NodeB)
 
     def test_create_sub_without_callback(self):
-        self.assertRaises(AssertionError, Subscriber, node=self._node, name="testsub")
+        self.assertRaises(AssertionError, Subscriber, node=self._node, from_name="testsub")
 
     def test_create_endpoint(self):
         def mycb(msg, headers):
             return "test"
 
-        sub = Subscriber(node=self._node, name="testsub", callback=mycb)
+        sub = Subscriber(node=self._node, from_name="testsub", callback=mycb)
         e = sub.create_endpoint()
 
         self.assertEquals(e._callback, mycb)
@@ -248,7 +277,7 @@ class TestSubscriber(PyonTestCase, RecvMockMixin):
         The goal of this test is to get messages routed to the callback mock.
         """
         cbmock = Mock()
-        sub = Subscriber(node=self._node, name="testsub", callback=cbmock)
+        sub = Subscriber(node=self._node, from_name="testsub", callback=cbmock)
 
         # tell the subscriber to create this as the main listening channel
         listen_channel_mock = self._setup_mock_channel(ch_type=SubscriberChannel, value="subbed", error_message="")
@@ -283,7 +312,7 @@ class TestRequestResponse(PyonTestCase, RecvMockMixin):
     def test_rr_client(self):
         """
         """
-        rr = RequestResponseClient(node=self._node, name="rr")
+        rr = RequestResponseClient(node=self._node, to_name="rr")
         rr.node.channel.return_value = self._setup_mock_channel()
 
         ret = rr.request("request")
@@ -353,7 +382,7 @@ class TestRPCClient(PyonTestCase, RecvMockMixin):
     def test_rpc_client(self, iomock):
         node = Mock(spec=NodeB)
 
-        rpcc = RPCClient(node=node, name="simply", iface=ISimpleInterface)
+        rpcc = RPCClient(node=node, to_name="simply", iface=ISimpleInterface)
         rpcc.node.channel.return_value = self._setup_mock_channel()
 
         self.assertTrue(hasattr(rpcc, 'simple'))
@@ -364,7 +393,7 @@ class TestRPCClient(PyonTestCase, RecvMockMixin):
         self.assertEquals(ret, "bidirmsg")
 
     def test_rpc_client_with_unnamed_args(self):
-        rpcc = RPCClient(name="simply", iface=ISimpleInterface)
+        rpcc = RPCClient(to_name="simply", iface=ISimpleInterface)
         self.assertRaises(AssertionError, rpcc.simple, "zap", "zip")
 
 @attr('UNIT')
@@ -502,7 +531,7 @@ class TestRPCServer(PyonTestCase, RecvMockMixin):
     def test_rpc_server(self):
         node = Mock(spec=NodeB)
         svc = SimpleService()
-        rpcs = RPCServer(node=node, name="testrpc", service=svc)
+        rpcs = RPCServer(node=node, from_name="testrpc", service=svc)
 
         # build a command object to be returned by the mocked channel
         class FakeMsg(object):

--- a/pyon/net/test/test_endpoint.py
+++ b/pyon/net/test/test_endpoint.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from pyon.core.interceptor.interceptor import Invocation
-from pyon.net.transport import NamePair
+from pyon.net.transport import NameTrio
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
@@ -173,7 +173,7 @@ class TestSendingBaseEndpoint(PyonTestCase):
     def test_init(self):
         ep = SendingBaseEndpoint(node=sentinel.node)
         self.assertEquals(ep.node, sentinel.node)
-        self.assertIsInstance(ep._send_name, NamePair)
+        self.assertIsInstance(ep._send_name, NameTrio)
 
     def test_init_with_to_name(self):
         ep = SendingBaseEndpoint(to_name=(sentinel.xp, sentinel.rkey))
@@ -188,17 +188,17 @@ class TestSendingBaseEndpoint(PyonTestCase):
         self.assertTrue(mocklog.warn.called)
 
     def test_init_with_to_name_namepair(self):
-        class MyNamePair(NamePair):
+        class MyNameTrio(NameTrio):
             def __init__(self):
                 self._exchange = sentinel.my_exchange
                 self._queue = sentinel.my_queue
 
-        ep = SendingBaseEndpoint(to_name=MyNamePair())
+        ep = SendingBaseEndpoint(to_name=MyNameTrio())
         self.assertEquals(ep._send_name.exchange, sentinel.my_exchange)
         self.assertEquals(ep._send_name.queue, sentinel.my_queue)
 
     def test_create_endpoint_calls_connect(self):
-        np = NamePair(sentinel.xp, sentinel.queue)
+        np = NameTrio(sentinel.xp, sentinel.queue)
         ep = SendingBaseEndpoint(node=Mock(spec=NodeB), to_name=np)
         e = ep.create_endpoint()
         e.channel.connect.assert_called_once_with(np)
@@ -248,7 +248,7 @@ class RecvMockMixin(object):
         ch.recv.side_effect = _ret
 
         # need to set a send_name for now
-        ch._send_name = NamePair('', '')
+        ch._send_name = NameTrio('', '')
 
         return ch
 

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -126,22 +126,25 @@ class NamePair(object):
     Internal representation of a name/queue.
     Created and used at the Endpoint layer and sometimes Channel layer.
     """
-    def __init__(self, exchange=None, queue=None):
+    def __init__(self, exchange=None, queue=None, binding=None):
         """
         Creates a NamePair.
 
-        If either exchange or queue is a 2-tuple, it will use that as a (exchange, queue) pair.
+        If either exchange or queue is a tuple, it will use that as a (exchange, queue, binding (optional)) triple.
 
         @param  exchange    An exchange name. You would typically use the sysname for that.
         @param  queue       Queue name.
+        @param  binding     A binding/routing key (used for both recv and send sides). Optional,
+                            and if not specified, defaults to the *internal* queue name.
         """
         if isinstance(exchange, tuple):
-            self._exchange, self._queue = exchange
+            self._exchange, self._queue, self._binding = exchange + ([None] *(3-len(exchange)))
         elif isinstance(queue, tuple):
-            self._exchange, self._queue = queue
+            self._exchange, self._queue, self._binding = queue + ([None] *(3-len(queue)))
         else:
             self._exchange  = exchange
             self._queue     = queue
+            self._binding   = binding
 
     @property
     def exchange(self):
@@ -151,8 +154,12 @@ class NamePair(object):
     def queue(self):
         return self._queue
 
+    @property
+    def binding(self):
+        return self._binding or self._queue
+
     def __str__(self):
-        return "NP (%s,%s)" % (self._exchange, self._queue)
+        return "NP (%s,%s,B: %s)" % (self._exchange, self._queue, self._binding)
 
 class FakeTransport(AMQPTransport, NamePair):
     def __init__(self):

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -4,16 +4,15 @@
 Transport layer abstractions
 
 TODOS:
-- port _sync_call from Channel layer for better error flow, add close callback to channel/client
 - split listen() into two subcalls (for StreamSubscriber)
 """
 
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
 
-from pyon.util.async import blocking_cb
 from pyon.util.log import log
 from gevent.event import AsyncResult
+from contextlib import contextmanager
 
 class TransportError(StandardError):
     pass
@@ -46,9 +45,47 @@ class AMQPTransport(BaseTransport):
             cls.__instance = AMQPTransport()
         return cls.__instance
 
+    @contextmanager
+    def _push_close_cb(self, client, callback):
+        client.add_on_close_callback(callback)
+        try:
+            yield callback
+        finally:
+            # PIKA BUG: v0.9.5, we need to specify the callback as a dict - this is fixed in git HEAD (13 Feb 2012)
+            de = {'handle': callback, 'one_shot': True}
+            client.callbacks.remove(client.channel_number, '_on_channel_close', de)
+
+    def _sync_call(self, client, func, cb_arg, *args, **kwargs):
+        """
+        Functionally similar to the generic blocking_cb but with error support that's Channel specific.
+        """
+        ar = AsyncResult()
+
+        def cb(*args, **kwargs):
+            ret = list(args)
+            if len(kwargs): ret.append(kwargs)
+            ar.set(ret)
+
+        eb = lambda ch, *args: ar.set(TransportError("_sync_call could not complete due to an error (%s)" % args))
+
+        kwargs[cb_arg] = cb
+        with self._push_close_cb(client, eb):
+            func(*args, **kwargs)
+            ret_vals = ar.get()
+
+        if isinstance(ret_vals, TransportError):
+            raise ret_vals
+
+        if len(ret_vals) == 0:
+            return None
+        elif len(ret_vals) == 1:
+            return ret_vals[0]
+        return tuple(ret_vals)
+
+
     def declare_exchange_impl(self, client, exchange, exchange_type='topic', durable=False, auto_delete=True):
         log.debug("AMQPTransport.declare_exchange_impl: %s, T %s, D %s, AD %s", exchange, exchange_type, durable, auto_delete)
-        blocking_cb(client.exchange_declare, 'callback',
+        self._sync_call(client, client.exchange_declare, 'callback',
                                              exchange=exchange,
                                              type=exchange_type,
                                              durable=durable,
@@ -56,11 +93,11 @@ class AMQPTransport(BaseTransport):
 
     def delete_exchange_impl(self, client, exchange, **kwargs):
         log.debug("AMQPTransport.delete_exchange_impl: %s", exchange)
-        blocking_cb(client.exchange_delete, 'callback', exchange=exchange)
+        self._sync_call(client, client.exchange_delete, 'callback', exchange=exchange)
 
     def declare_queue_impl(self, client, queue, durable=False, auto_delete=True):
         log.debug("AMQPTransport.declare_queue_impl: %s, D %s, AD %s", queue, durable, auto_delete)
-        frame = blocking_cb(client.queue_declare, 'callback',
+        frame = self._sync_call(client, client.queue_declare, 'callback',
                                 queue=queue or '',
                                 auto_delete=auto_delete,
                                 durable=durable)
@@ -68,19 +105,18 @@ class AMQPTransport(BaseTransport):
 
     def delete_queue_impl(self, client, queue, **kwargs):
         log.debug("AMQPTransport.delete_queue_impl: %s", queue)
-        blocking_cb(client.queue_delete, 'callback', queue=queue)
+        self._sync_call(client, client.queue_delete, 'callback', queue=queue)
 
     def bind_impl(self, client, exchange, queue, binding):
         log.debug("AMQPTransport.bind_impl: EX %s, Q %s, B %s", exchange, queue, binding)
-        blocking_cb(client.queue_bind, 'callback',
+        self._sync_call(client, client.queue_bind, 'callback',
                                         queue=queue,
                                         exchange=exchange,
                                         routing_key=binding)
 
     def unbind_impl(self, client, exchange, queue, binding):
         log.debug("AMQPTransport.unbind_impl: EX %s, Q %s, B %s", exchange, queue, binding)
-        blocking_cb(client.queue_unbind, 'callback', queue=queue,
+        self._sync_call(client, client.queue_unbind, 'callback', queue=queue,
                                                      exchange=exchange,
                                                      routing_key=binding)
-
 

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -33,6 +33,9 @@ class BaseTransport(object):
     def unbind_impl(self, client, exchange, queue, binding):
         raise NotImplementedError()
 
+    def setup_listener(self, binding, default_cb):
+        raise NotImplementedError()
+
 class AMQPTransport(BaseTransport):
     """
     This is STATELESS. You can make instances of it, but no need to (true singleton).
@@ -119,6 +122,12 @@ class AMQPTransport(BaseTransport):
         self._sync_call(client, client.queue_unbind, 'callback', queue=queue,
                                                      exchange=exchange,
                                                      routing_key=binding)
+
+    def setup_listener(self, binding, default_cb):
+        """
+        Calls setup listener via the default callback passed in.
+        """
+        return default_cb(self, binding)
 
 
 class NamePair(object):

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -153,3 +153,31 @@ class NamePair(object):
 
     def __str__(self):
         return "NP (%s,%s)" % (self._exchange, self._queue)
+
+class FakeTransport(AMQPTransport, NamePair):
+    def __init__(self):
+        self._exchange = "wizzzard"
+        self._queue = "hello"
+
+    def declare_exchange_impl(self, client, exchange, exchange_type='topic', durable=False, auto_delete=True):
+        log.error("I AM THE WIZZZARD")
+        return AMQPTransport.declare_exchange_impl(self, client, exchange, exchange_type=exchange_type, durable=durable, auto_delete=auto_delete)
+
+
+
+
+
+
+
+
+class NewChannel(object):
+    def __init__(self, to_name=None, from_name=None, transport=None):
+        pass
+
+def sample():
+    from pyon.container.cc import Container
+    xn = Container.instance.ex_manager.create_xn()         # returns ExchangeName-derived item
+    ch = NewChannel(to_name=xn, transport=xn)              # uses exchange manager for broker interaction
+
+    ch = NewChannel(to_name=('ex', 'hello'))               # no transport given == use AMQP default, name specified in the old style
+

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -120,3 +120,36 @@ class AMQPTransport(BaseTransport):
                                                      exchange=exchange,
                                                      routing_key=binding)
 
+
+class NamePair(object):
+    """
+    Internal representation of a name/queue.
+    Created and used at the Endpoint layer and sometimes Channel layer.
+    """
+    def __init__(self, exchange=None, queue=None):
+        """
+        Creates a NamePair.
+
+        If either exchange or queue is a 2-tuple, it will use that as a (exchange, queue) pair.
+
+        @param  exchange    An exchange name. You would typically use the sysname for that.
+        @param  queue       Queue name.
+        """
+        if isinstance(exchange, tuple):
+            self._exchange, self._queue = exchange
+        elif isinstance(queue, tuple):
+            self._exchange, self._queue = queue
+        else:
+            self._exchange  = exchange
+            self._queue     = queue
+
+    @property
+    def exchange(self):
+        return self._exchange
+
+    @property
+    def queue(self):
+        return self._queue
+
+    def __str__(self):
+        return "NP (%s,%s)" % (self._exchange, self._queue)

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -130,14 +130,14 @@ class AMQPTransport(BaseTransport):
         return default_cb(self, binding)
 
 
-class NamePair(object):
+class NameTrio(object):
     """
-    Internal representation of a name/queue.
+    Internal representation of a name/queue/binding (optional).
     Created and used at the Endpoint layer and sometimes Channel layer.
     """
     def __init__(self, exchange=None, queue=None, binding=None):
         """
-        Creates a NamePair.
+        Creates a NameTrio.
 
         If either exchange or queue is a tuple, it will use that as a (exchange, queue, binding (optional)) triple.
 
@@ -170,7 +170,7 @@ class NamePair(object):
     def __str__(self):
         return "NP (%s,%s,B: %s)" % (self.exchange, self.queue, self.binding)
 
-class FakeTransport(AMQPTransport, NamePair):
+class FakeTransport(AMQPTransport, NameTrio):
     def __init__(self):
         self._exchange = "wizzzard"
         self._queue = "hello"

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+"""
+Transport layer abstractions
+
+TODOS:
+- port _sync_call from Channel layer for better error flow, add close callback to channel/client
+- split listen() into two subcalls (for StreamSubscriber)
+"""
+
+__author__ = 'Dave Foster <dfoster@asascience.com>'
+__license__ = 'Apache 2.0'
+
+from pyon.util.async import blocking_cb
+from pyon.util.log import log
+from gevent.event import AsyncResult
+
+class TransportError(StandardError):
+    pass
+
+class BaseTransport(object):
+    def declare_exchange_impl(self, client, exchange, **kwargs):
+        raise NotImplementedError()
+    def delete_exchange_impl(self, client, exchange, **kwargs):
+        raise NotImplementedError()
+
+    def declare_queue_impl(self, client, queue, **kwargs):
+        raise NotImplementedError()
+    def delete_queue_impl(self, client, queue, **kwargs):
+        raise NotImplementedError()
+
+    def bind_impl(self, client, exchange, queue, binding):
+        raise NotImplementedError()
+    def unbind_impl(self, client, exchange, queue, binding):
+        raise NotImplementedError()
+
+class AMQPTransport(BaseTransport):
+    """
+    This is STATELESS. You can make instances of it, but no need to (true singleton).
+    """
+    __instance = None
+
+    @classmethod
+    def get_instance(cls):
+        if cls.__instance is None:
+            cls.__instance = AMQPTransport()
+        return cls.__instance
+
+    def declare_exchange_impl(self, client, exchange, exchange_type='topic', durable=False, auto_delete=True):
+        log.debug("AMQPTransport.declare_exchange_impl: %s, T %s, D %s, AD %s", exchange, exchange_type, durable, auto_delete)
+        blocking_cb(client.exchange_declare, 'callback',
+                                             exchange=exchange,
+                                             type=exchange_type,
+                                             durable=durable,
+                                             auto_delete=auto_delete)
+
+    def delete_exchange_impl(self, client, exchange, **kwargs):
+        log.debug("AMQPTransport.delete_exchange_impl: %s", exchange)
+        blocking_cb(client.exchange_delete, 'callback', exchange=exchange)
+
+    def declare_queue_impl(self, client, queue, durable=False, auto_delete=True):
+        log.debug("AMQPTransport.declare_queue_impl: %s, D %s, AD %s", queue, durable, auto_delete)
+        frame = blocking_cb(client.queue_declare, 'callback',
+                                queue=queue or '',
+                                auto_delete=auto_delete,
+                                durable=durable)
+        return frame.method.queue
+
+    def delete_queue_impl(self, client, queue, **kwargs):
+        log.debug("AMQPTransport.delete_queue_impl: %s", queue)
+        blocking_cb(client.queue_delete, 'callback', queue=queue)
+
+    def bind_impl(self, client, exchange, queue, binding):
+        log.debug("AMQPTransport.bind_impl: EX %s, Q %s, B %s", exchange, queue, binding)
+        blocking_cb(client.queue_bind, 'callback',
+                                        queue=queue,
+                                        exchange=exchange,
+                                        routing_key=binding)
+
+    def unbind_impl(self, client, exchange, queue, binding):
+        log.debug("AMQPTransport.unbind_impl: EX %s, Q %s, B %s", exchange, queue, binding)
+        blocking_cb(client.queue_unbind, 'callback', queue=queue,
+                                                     exchange=exchange,
+                                                     routing_key=binding)
+
+

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -138,9 +138,9 @@ class NamePair(object):
                             and if not specified, defaults to the *internal* queue name.
         """
         if isinstance(exchange, tuple):
-            self._exchange, self._queue, self._binding = exchange + ([None] *(3-len(exchange)))
+            self._exchange, self._queue, self._binding = list(exchange) + ([None] *(3-len(exchange)))
         elif isinstance(queue, tuple):
-            self._exchange, self._queue, self._binding = queue + ([None] *(3-len(queue)))
+            self._exchange, self._queue, self._binding = list(queue) + ([None] *(3-len(queue)))
         else:
             self._exchange  = exchange
             self._queue     = queue
@@ -159,7 +159,7 @@ class NamePair(object):
         return self._binding or self._queue
 
     def __str__(self):
-        return "NP (%s,%s,B: %s)" % (self._exchange, self._queue, self._binding)
+        return "NP (%s,%s,B: %s)" % (self.exchange, self.queue, self.binding)
 
 class FakeTransport(AMQPTransport, NamePair):
     def __init__(self):

--- a/scripts/generate_interfaces.py
+++ b/scripts/generate_interfaces.py
@@ -50,6 +50,7 @@ import interface.objects
 from pyon.core.bootstrap import IonObject
 from pyon.service.service import BaseService, BaseClients
 from pyon.net.endpoint import RPCClient, ProcessRPCClient
+from pyon.util.log import log
 ${dep_client_imports}
 
 ${clientsholder}
@@ -155,15 +156,19 @@ ${methods}
     'obj_arg_no_def': "'${name}': ${name}",
     'rpcclient':
 '''class ${name}Client(RPCClient, ${name}ClientMixin):
-    def __init__(self, to_name=None, node=None, **kwargs):
-        to_name = to_name or '${targetname}'
+    def __init__(self, to_name=None, name=None, node=None, **kwargs):
+        if name is not None:
+            log.warn("${name}Client: 'name' parameter is deprecated, please use to_name")
+        to_name = to_name or name or '${targetname}'
         RPCClient.__init__(self, to_name=to_name, node=node, **kwargs)
         ${name}ClientMixin.__init__(self)
 ''',
     'processrpcclient':
 '''class ${name}ProcessClient(ProcessRPCClient, ${name}ClientMixin):
-    def __init__(self, process=None, to_name=None, node=None, **kwargs):
-        to_name = to_name or '${targetname}'
+    def __init__(self, process=None, to_name=None, name=None, node=None, **kwargs):
+        if name is not None:
+            log.warn("${name}Client: 'name' parameter is deprecated, please use to_name")
+        to_name = to_name or name or '${targetname}'
         ProcessRPCClient.__init__(self, process=process, to_name=to_name, node=node, **kwargs)
         ${name}ClientMixin.__init__(self)
 '''

--- a/scripts/generate_interfaces.py
+++ b/scripts/generate_interfaces.py
@@ -2,7 +2,7 @@
 
 # Ion utility for generating interfaces from object definitions (and vice versa).
 
-__author__ = 'Adam R. Smith, Thomas Lennan, Stephen Henrie'
+__author__ = 'Adam R. Smith, Thomas Lennan, Stephen Henrie, Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
 
 import ast
@@ -155,16 +155,16 @@ ${methods}
     'obj_arg_no_def': "'${name}': ${name}",
     'rpcclient':
 '''class ${name}Client(RPCClient, ${name}ClientMixin):
-    def __init__(self, name=None, node=None, **kwargs):
-        name = name or '${targetname}'
-        RPCClient.__init__(self, name=name, node=node, **kwargs)
+    def __init__(self, to_name=None, node=None, **kwargs):
+        to_name = to_name or '${targetname}'
+        RPCClient.__init__(self, to_name=to_name, node=node, **kwargs)
         ${name}ClientMixin.__init__(self)
 ''',
     'processrpcclient':
 '''class ${name}ProcessClient(ProcessRPCClient, ${name}ClientMixin):
-    def __init__(self, process=None, name=None, node=None, **kwargs):
-        name = name or '${targetname}'
-        ProcessRPCClient.__init__(self, process=process, name=name, node=node, **kwargs)
+    def __init__(self, process=None, to_name=None, node=None, **kwargs):
+        to_name = to_name or '${targetname}'
+        ProcessRPCClient.__init__(self, process=process, to_name=to_name, node=node, **kwargs)
         ${name}ClientMixin.__init__(self)
 '''
 }


### PR DESCRIPTION
This PR represents a major refactor to support the Container's Exchange Manager class and is wholly contained within pyon.  If EMS (via coi-services) is present in the system, Exchange Manager will interact with it and allow the EMS to do the actual bare-metal work.

This should be mergeable with MINIMAL disruption to anyone - using the container XO is currently a buy-in style - you have to explicitly use it.

Some major pieces touched:
- Beginnings of a Transport layer refactor, which `pyon.net.channel` is built on top of. Abstracts actual bare-metal interactions and allows redirection (for the container's exchange manager to make decisions on).
- `pyon.net.endpoint` improvements:
  - `SendingBaseEndpoint` to mirror listening side - all send-first endpoints based on this
  - `to_name` and `from_name` kwargs where it makes sense
- Full Container Exchange Object testing (UNIT/INT, group='exchange')

Several TODOs remain and will be incorporated as time allows:
- Tests for Transport layer
- Finish porting Transport layer fully (some remaining AMQP interactions in Channel layer)
- AcceptedChannel needs underlying transport/nametrio
- Tests for pubsub via XP (to establish pattern)
- Container ExManager should cache any AMQP interaction for no duplicates
- Switch service clients to use XOs automatically (will be done soon)
- `delete_<x>_by_name` API
