### PR TITLE
Added support for syslog logging

### DIFF
--- a/pyon/util/log.py
+++ b/pyon/util/log.py
@@ -6,6 +6,41 @@ __license__ = 'Apache 2.0'
 import __builtin__
 import logging
 import sys
+import socket
+from logging.handlers import SysLogHandler, SYSLOG_UDP_PORT
+
+class Pyon_SysLogHandler(logging.handlers.SysLogHandler):
+    """
+    Class to override built-in syslog handler to work around
+    issue where log records that are over MTU get dropped.
+    We will chunk the message up so it at least gets logged.
+    """ 
+    MTU = 1400
+
+    def __init__(self, address=('localhost', SYSLOG_UDP_PORT),
+                 facility=SysLogHandler.LOG_USER, socktype=socket.SOCK_DGRAM, MTU=1400):
+        SysLogHandler.__init__(self, address, facility, socktype)
+        self.MTU = MTU
+        
+    def emit(self, record):
+        message = record.getMessage()
+        msg_len = len(message)
+        if msg_len > self.MTU:
+            # Chunk message into MTU size parts
+            start_index = 0
+            end_index = self.MTU - 1
+            while True:
+                msg = message[start_index:end_index]
+                rec = logging.LogRecord(record.name, record.levelno, record.pathname, record.lineno, msg, None, record.exc_info, record.funcName)
+                SysLogHandler.emit(self, rec)
+                start_index = start_index + self.MTU
+                if start_index >= msg_len:
+                    break
+                end_index = end_index + self.MTU
+                if end_index > msg_len:
+                    end_index = msg_len - 1
+        else:
+            SysLogHandler.emit(self, record)
 
 # List of module names that will pass-through for the magic import scoping. This can be modified.
 import_paths = [__name__]


### PR DESCRIPTION
Implemented class to override built-in syslog handler since it drops log records that exceed the transport layer's MTU.  My class chunks long log records into sub-MTU size log records to at least ensure the log information is recorded.
