### PR TITLE
Generate random sysname on testing scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ unittest.out
 interface/*
 cc-pid*
 .coverage
+
+cover/

--- a/pyon/core/bootstrap.py
+++ b/pyon/core/bootstrap.py
@@ -8,6 +8,7 @@ from pyon.core.registry import IonObjectRegistry
 from pyon.service.service import IonServiceRegistry
 from pyon.util.config import CFG
 from pyon.util.containers import is_basic_identifier
+import uuid
 
 import os
 
@@ -49,8 +50,11 @@ pyon_initialized = False
 # DANGER: Don't import sys_name from here, use get_sys_name() instead.
 # NOTE: This sys_name may be changed by the container later if command line args override
 sys_name = CFG.system.name or 'ion_%s' % os.uname()[1].replace('.', '_')
+testing_sys_name = "ion_test_%s" % str(uuid.uuid4())[0:6]
 
 def get_sys_name():
+    if CFG.system.testing:
+        return testing_sys_name
     return sys_name
 
 # OBJECTS. Object and message definitions.

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -153,7 +153,7 @@ class IonIntegrationTestCase(unittest.TestCase):
         self.addCleanup(patcher.stop)
 
     def _force_clean(self):
-        from pyon.core.bootstrap import sys_name
+        from pyon.core.bootstrap import get_sys_name
         from pyon.datastore.datastore import DatastoreManager
         if DatastoreManager.persistent is None:
             DatastoreManager.persistent = not CFG.system.mockdb
@@ -162,7 +162,7 @@ class IonIntegrationTestCase(unittest.TestCase):
         else:
             datastore = CouchDB_DataStore()
         dbs = datastore.list_datastores()
-        things_to_clean = filter(lambda x: x.startswith('%s_' % sys_name), dbs)
+        things_to_clean = filter(lambda x: x.startswith('%s_' % get_sys_name()), dbs)
         try:
             for thing in things_to_clean:
                 datastore.delete_datastore(datastore_name=thing)

--- a/scripts/pycc.py
+++ b/scripts/pycc.py
@@ -117,7 +117,7 @@ def main(opts, *args, **kwargs):
             initialize_logging()
 
         # Set that system is not testing. We are running as standalone container
-        CFG.system.testing = False
+        dict_merge(CFG, {'system':{'testing':False}}, True)
 
         # Load any additional config paths and merge them into main config
         if len(opts.config):


### PR DESCRIPTION
Not sure if this is the correct approach, but seems to work.  Should limit the whole broker-cycling thing.
