### PR TITLE
Make sysname generation more robust and follow the rules

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -62,8 +62,7 @@ class Container(BaseContainerAgent):
         from pyon.core import bootstrap
         bootstrap.container_instance = self
         bootstrap.assert_configuration(CFG)
-        bootstrap.sys_name = CFG.system.name or bootstrap.sys_name
-        log.debug("Container (sysname=%s) initializing ..." % bootstrap.sys_name)
+        log.debug("Container (sysname=%s) initializing ..." % bootstrap.get_sys_name())
 
         # Keep track of the overrides from the command-line, so they can trump app/rel file data
         self.spawn_args = kwargs
@@ -105,10 +104,9 @@ class Container(BaseContainerAgent):
 
         # write out a PID file containing our agent messaging name
         with open(self.pidfile, 'w') as f:
-            from pyon.core.bootstrap import get_sys_name
             pid_contents = {'messaging': dict(CFG.server.amqp),
                             'container-agent': self.name,
-                            'container-xp': get_sys_name() }
+                            'container-xp': bootstrap.get_sys_name() }
             f.write(msgpack.dumps(pid_contents))
             atexit.register(self._cleanup_pid)
             self._capabilities.append("PID_FILE")

--- a/pyon/core/bootstrap.py
+++ b/pyon/core/bootstrap.py
@@ -49,13 +49,17 @@ pyon_initialized = False
 # This sets the sys_name.
 # DANGER: Don't import sys_name from here, use get_sys_name() instead.
 # NOTE: This sys_name may be changed by the container later if command line args override
-sys_name = CFG.system.name or 'ion_%s' % os.uname()[1].replace('.', '_')
+default_sys_name = 'ion_%s' % os.uname()[1].replace('.', '_')
 testing_sys_name = "ion_test_%s" % str(uuid.uuid4())[0:6]
 
 def get_sys_name():
+    if CFG.system.name:
+        return CFG.system.name
+
     if CFG.system.testing:
         return testing_sys_name
-    return sys_name
+
+    return default_sys_name
 
 # OBJECTS. Object and message definitions.
 # Make a default factory for IonObjects

--- a/pyon/event/test/test_event.py
+++ b/pyon/event/test/test_event.py
@@ -29,7 +29,7 @@ class TestEventPublisher(IonUnitTestCase):
         self._pub = EventPublisher(node=self._node)
 
     def test_init(self):
-        self.assertEquals(self._pub._send_name.exchange, "%s.pyon.events" % bootstrap.sys_name)
+        self.assertEquals(self._pub._send_name.exchange, "%s.pyon.events" % bootstrap.get_sys_name())
         self.assertEquals(self._pub._send_name.queue, None)
 
         pub = EventPublisher(node=self._node, xp=sentinel.xp)
@@ -161,7 +161,7 @@ class TestEventSubscriber(IonUnitTestCase):
         self._sub = EventSubscriber(node=self._node, callback=self._cb)
 
     def test_init(self):
-        self.assertEquals(self._sub._recv_name.exchange, "%s.pyon.events" % bootstrap.sys_name)
+        self.assertEquals(self._sub._recv_name.exchange, "%s.pyon.events" % bootstrap.get_sys_name())
         self.assertEquals(self._sub._recv_name.queue, None)
         self.assertEquals(self._sub._binding, "*.#")
         self.assertEquals(self._sub._callback, self._cb)
@@ -182,10 +182,10 @@ class TestEventSubscriber(IonUnitTestCase):
     def test_init_with_queue_name(self):
         sub = EventSubscriber(node=self._node, callback=self._cb, xp_name=sentinel.xp, queue_name=str(sentinel.queue))
         self.assertEquals(sub._recv_name.exchange, sentinel.xp)
-        self.assertEquals(sub._recv_name.queue, "%s.%s" % (bootstrap.sys_name, str(sentinel.queue)))
+        self.assertEquals(sub._recv_name.queue, "%s.%s" % (bootstrap.get_sys_name(), str(sentinel.queue)))
 
     def test_init_with_queue_name_with_sysname(self):
-        queue_name = "%s-dacshund" % bootstrap.sys_name
+        queue_name = "%s-dacshund" % bootstrap.get_sys_name()
         sub = EventSubscriber(node=self._node, callback=self._cb, xp_name=sentinel.xp, queue_name=queue_name)
         self.assertEquals(sub._recv_name.exchange, sentinel.xp)
         self.assertEquals(sub._recv_name.queue, queue_name)


### PR DESCRIPTION
@jamie-cyber1 indicated a problem in that it did not respect an explicitly set sys_name.  It should now.
