### PR TITLE
Msgpack numpy

### DIFF
--- a/pyon/core/interceptor/codec.py
+++ b/pyon/core/interceptor/codec.py
@@ -29,6 +29,7 @@ class CodecInterceptor(Interceptor):
 
         # Horrible, hacky workaround for msgpack issue
         # See http://jira.msgpack.org/browse/MSGPACK-15
+        #@todo replace this with use_list in msgpack.unpackb !!!
         def convert_tuples_to_lists(obj):
             if isinstance(obj, tuple):
                 res = list(obj)

--- a/pyon/core/interceptor/encode.py
+++ b/pyon/core/interceptor/encode.py
@@ -4,9 +4,19 @@ from pyon.core.interceptor.interceptor import Interceptor
 from pyon.util.log import log
 import numpy
 
+"""
+@todod Add other ion object stuff here...
+"""
+
+
 def decode_ion( obj):
+    """
+    MsgPack object hook to decode any ion object as part of the message pack walk rather than implementing it again in
+    pyon
+    """
     if "__ion_array__" in obj:
-        return numpy.array(obj['content'],dtype=numpy.dtype(obj['shape']['type']))
+        # Shape is currently implicit because tolist encoding makes a list of lists for a 2d array.
+        return numpy.array(obj['content'],dtype=numpy.dtype(obj['header']['type']))
 
     elif '__complex__' in obj:
         return complex(obj['real'], obj['imag'])
@@ -14,10 +24,12 @@ def decode_ion( obj):
     return obj
 
 def encode_ion( obj):
+    """
+    MsgPack object hook to encode any ion object as part of the message pack walk rather than implementing it again in
+    pyon
+    """
     if isinstance(obj, numpy.ndarray):
-        new_obj = {"shape":{"type":str(obj.dtype),"nd":len(obj.shape),"lengths":obj.shape},"content":obj.tolist(),"__ion_array__":True}
-
-        return new_obj
+        return {"header":{"type":str(obj.dtype),"nd":len(obj.shape),"shape":obj.shape},"content":obj.tolist(),"__ion_array__":True}
 
     elif isinstance(obj, complex):
         return {'__complex__': True, 'real': obj.real, 'imag': obj.imag}

--- a/pyon/core/interceptor/encode.py
+++ b/pyon/core/interceptor/encode.py
@@ -15,14 +15,19 @@ def decode_ion( obj):
 
 def encode_ion( obj):
     if isinstance(obj, numpy.ndarray):
-        return {"shape":{"type":str(obj.dtype),"nd":len(obj.shape),"lengths":obj.shape},"content":obj.tolist(),"__ion_array__":True}
+        new_obj = {"shape":{"type":str(obj.dtype),"nd":len(obj.shape),"lengths":obj.shape},"content":obj.tolist(),"__ion_array__":True}
+
+        return new_obj
 
     elif isinstance(obj, complex):
         return {'__complex__': True, 'real': obj.real, 'imag': obj.imag}
 
+    if isinstance(obj, (numpy.float, numpy.float16, numpy.float32, numpy.float64)):
+        raise ValueError('Can not encode numpy scalars!')
+
     else:
         # Must raise type error to avoid recursive failure
-        raise TypeError('Unknown type in user specified encoder')
+        raise TypeError('Unknown type "%s" in user specified encoder: "%s"' % (str(type(obj)), str(obj)))
     return obj
 
 

--- a/pyon/core/interceptor/test/interceptor_test.py
+++ b/pyon/core/interceptor/test/interceptor_test.py
@@ -23,14 +23,10 @@ class InterceptorTest(PyonTestCase):
 
         a = np.array([90,8010,3,14112,3.14159265358979323846264],dtype='float32')
 
-        print 'Array Type:',type(a[0])
-        print 'List Type:',type(a.tolist()[0])
-
         invoke = Invocation()
         invoke.message = a
         codec = EncodeInterceptor()
 
-        print 'LSSLSJSL',type(invoke.message)
         mangled = codec.outgoing(invoke)
 
         received = codec.incoming(mangled)

--- a/pyon/core/interceptor/test/interceptor_test.py
+++ b/pyon/core/interceptor/test/interceptor_test.py
@@ -4,7 +4,7 @@
 @description test lib for interceptor
 '''
 import unittest
-from pyon.core.interceptor.codec import CodecInterceptor
+from pyon.core.interceptor.encode import EncodeInterceptor
 from pyon.core.interceptor.interceptor import Invocation
 from pyon.util import log
 from pyon.util.unit_test import PyonTestCase
@@ -21,24 +21,29 @@ class InterceptorTest(PyonTestCase):
     @unittest.skipIf(not _have_numpy,'No numpy')
     def test_numpy_codec(self):
 
-        a = np.array([(90,8010,3,14112,3.14159265358979323846264)],dtype='float32')
+        a = np.array([90,8010,3,14112,3.14159265358979323846264],dtype='float32')
+
+        print 'Array Type:',type(a[0])
+        print 'List Type:',type(a.tolist()[0])
+
         invoke = Invocation()
         invoke.message = a
-        codec = CodecInterceptor()
+        codec = EncodeInterceptor()
 
+        print 'LSSLSJSL',type(invoke.message)
         mangled = codec.outgoing(invoke)
 
         received = codec.incoming(mangled)
 
         b = received.message
-        comp = (a==b)
-        self.assertTrue(comp.all())
+        self.assertTrue((a==b).all())
+
     @unittest.skipIf(not _have_numpy,'No numpy')
     def test_packed_numpy(self):
         a = np.array([(90,8010,3,14112,3.14159265358979323846264)],dtype='float32')
         invoke = Invocation()
         invoke.message = {'double stuffed':[a,a,a]}
-        codec = CodecInterceptor()
+        codec = EncodeInterceptor()
 
         mangled = codec.outgoing(invoke)
 
@@ -47,5 +52,4 @@ class InterceptorTest(PyonTestCase):
         b = received.message
         c = b.get('double stuffed')
         for d in c:
-            e = (a==d)
-            self.assertTrue(e.all())
+            self.assertTrue((a==d).all())

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -196,16 +196,6 @@ class IonObjectSerializer(IonObjectSerializationBase):
         if isinstance(obj, IonObjectBase):
             res = dict((k, v) for k, v in obj.__dict__.iteritems() if k in obj._schema or k in ['_id', '_rev', 'type_'])
             return res
-        if _have_numpy:
-            if isinstance(obj,np.ndarray):
-                log.debug('got numpy: %s', type(obj))
-                res = {'numpy': {
-                    'type':str(obj.dtype),
-                    'shape':obj.shape,
-                    'body':obj.tostring()
-                }}
-                log.debug('res: %s', res)
-                return res
 
         return obj
 
@@ -238,18 +228,6 @@ class IonObjectDeserializer(IonObjectSerializationBase):
                     setattr(ion_obj, k, v)
 
             return ion_obj
-        if _have_numpy:
-            if isinstance(obj, dict):
-                msg = obj.get('numpy',False)
-                log.debug('message = %s', msg)
-                if msg:
-                    shape = msg.get('shape')
-                    type = msg.get('type')
-                    data = msg.get('body')
-                    log.debug('Numpy Array Detected:\n  type: %s\n  shape: %s\n  body: %s',type,shape,data)
-                    ret = np.fromstring(string=data,dtype=type).reshape(shape)
-                    return np.array(ret)
-
 
         return obj
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(  name = 'pyon',
         test_suite = 'pyon',
         install_requires = [
             # Patched greenlet to work on ARMS
-            'cython==0.15.1',
             'greenlet==0.3.1-p1',
             'gevent==0.13.6',
             'simplejson==2.1.6',

--- a/setup.py
+++ b/setup.py
@@ -41,15 +41,16 @@ setup(  name = 'pyon',
             },
         dependency_links = [
             'http://ooici.net/releases',
-            'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler'
+            'https://github.com/ooici/msgpack-python/tarball/master#egg=msgpack-python-0.1.13',            'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler'
         ],
         test_suite = 'pyon',
         install_requires = [
             # Patched greenlet to work on ARMS
+            'cython==0.15.1',
             'greenlet==0.3.1-p1',
             'gevent==0.13.6',
             'simplejson==2.1.6',
-            'msgpack-python==0.1.9',
+            'msgpack-python==0.1.13',
             'setproctitle==1.1.2',
             'pyyaml==3.10',
             'pika==0.9.5',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(  name = 'pyon',
             },
         dependency_links = [
             'http://ooici.net/releases',
-            'https://github.com/ooici/msgpack-python/tarball/master#egg=msgpack-python-0.1.13',            'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler'
+            'https://github.com/ooici/msgpack-python/tarball/master#egg=msgpack-python-0.1.13',
+            'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler'
         ],
         test_suite = 'pyon',
         install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(  name = 'pyon',
             },
         dependency_links = [
             'http://ooici.net/releases',
-            'https://github.com/ooici/msgpack-python/tarball/master#egg=msgpack-python-0.1.13',
             'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler'
         ],
         test_suite = 'pyon',


### PR DESCRIPTION
Added initial support for numpy arrays encoded using msgpack object hook.
This method is inefficient because it promotes all floating point numbers to double during transfer and specifies the type of each atom in the array.

Future work in COI can make use of the msgpack object hook to avoid walking the object tree in pyon. MsgPack allows you to provide your own method for packing an unpacking object types.

David
