### PR TITLE
Refactor arg_check

### DIFF
--- a/examples/service/arg_check_example.py
+++ b/examples/service/arg_check_example.py
@@ -5,7 +5,7 @@
 @date 03/27/12 15:30
 @description DESCRIPTION
 '''
-from pyon.util.arg_check import validateIsInstance, validateIn, validateEqual, validateTrue
+from pyon.util.arg_check import validate_is_instance, validate_in, validate_equal, validate_true
 
 
 class ArgCheckService(object):
@@ -19,33 +19,33 @@ class ArgCheckService(object):
         '''
         Say you were expecting an integer from the client...
         '''
-        validateIsInstance(val,int,'Value is not an integer.')
+        validate_is_instance(val,int,'Value is not an integer.')
         return val
 
     def pass_float(self, val=1.0):
         '''
         Say you were expecting a float from the client
         '''
-        validateIsInstance(val,float,'Value is not a float.')
+        validate_is_instance(val,float,'Value is not a float.')
         return val
 
     def handle_list(self, needle, haystack):
         '''
         You needed to be certain that something was in the list or dict
         '''
-        validateIn(needle,haystack,'Can\'t find %s in %s.' % (needle, haystack))
+        validate_in(needle,haystack,'Can\'t find %s in %s.' % (needle, haystack))
         return needle
 
     def check_equality(self, a,b):
         '''
         You needed to be sure that two items we're equivalent
         '''
-        validateEqual(a,b,'%s != %s' %(str(a), str(b)))
+        validate_equal(a,b,'%s != %s' %(str(a), str(b)))
         return True
 
     def list_len(self,l):
         '''
         You needed to be certain that a list had len >0
         '''
-        validateTrue(len(l)>0, 'list=%s was empty.' % str(l))
+        validate_true(len(l)>0, 'list=%s was empty.' % str(l))
 

--- a/prototype/transforms/dct.py
+++ b/prototype/transforms/dct.py
@@ -6,7 +6,7 @@
 @description Discrete Cosine Transform
 '''
 from pyon.ion.transform import TransformBenchTesting
-from pyon.util.arg_check import validateIsInstance
+from pyon.util.arg_check import validate_is_instance
 
 class TransformDCT(TransformBenchTesting):
     '''
@@ -16,7 +16,7 @@ class TransformDCT(TransformBenchTesting):
     @staticmethod
     def dct(vector):
         import numpy as np
-        validateIsInstance(vector,np.ndarray)
+        validate_is_instance(vector,np.ndarray)
         N = vector.size
 
         x = list()

--- a/prototype/transforms/linear.py
+++ b/prototype/transforms/linear.py
@@ -6,7 +6,7 @@
 @description Linear Phase Shift
 '''
 from pyon.ion.transform import TransformBenchTesting
-from pyon.util.arg_check import validateIsInstance
+from pyon.util.arg_check import validate_is_instance
 
 class TransformLinear(TransformBenchTesting):
     '''
@@ -14,7 +14,7 @@ class TransformLinear(TransformBenchTesting):
     '''
     @staticmethod
     def shift(vector):
-        validateIsInstance(vector,list)
+        validate_is_instance(vector,list)
         N = len(vector)
         x = list()
         for i in xrange(N):
@@ -37,7 +37,7 @@ class TransformSquare(TransformBenchTesting):
 
     @staticmethod
     def shift(vector):
-        validateIsInstance(vector, list)
+        validate_is_instance(vector, list)
         N = len(vector)
         x = list()
         for i in xrange(N):
@@ -58,7 +58,7 @@ class TransformInPlace(TransformBenchTesting):
     '''
     @staticmethod
     def shift(vector):
-        validateIsInstance(vector,list)
+        validate_is_instance(vector,list)
         N = len(vector)
         x = vector[0]
         vector[0] = vector[N-1]

--- a/pyon/datastore/datastore.py
+++ b/pyon/datastore/datastore.py
@@ -8,7 +8,7 @@ from pyon.core.exception import BadRequest, NotFound
 from pyon.ion.resource import AT
 from pyon.util.containers import DotDict, get_ion_ts, get_safe
 from pyon.util.log import log
-from pyon.util.arg_check import validateTrue
+from pyon.util.arg_check import validate_true
 
 
 class DataStore(object):
@@ -318,7 +318,7 @@ class DatastoreManager(object):
         @param profile  One of known constants determining the use of the store
         @param config  Override config to use
         """
-        validateTrue(ds_name,'ds_name must be provided')
+        validate_true(ds_name,'ds_name must be provided')
         if ds_name in self._datastores:
             log.debug("get_datastore(): Found instance of store '%s'" % ds_name)
             return self._datastores[ds_name]

--- a/pyon/util/arg_check.py
+++ b/pyon/util/arg_check.py
@@ -41,7 +41,7 @@ def scoped_validation():
     return name,lineno
 
 
-def validateTrue(conditional, message='', exception=None):
+def validate_true(conditional, message='', exception=None):
     '''
     Manages an validation
     @param conditional The conditional statement to be evaluated
@@ -53,7 +53,7 @@ def validateTrue(conditional, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateEqual(a,b,message='',exception=None):
+def validate_equal(a,b,message='',exception=None):
     '''
     Raises an exception if a != b
     @param a 
@@ -66,7 +66,7 @@ def validateEqual(a,b,message='',exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateNotEqual(a,b,message='',exception=None):
+def validate_not_equal(a,b,message='',exception=None):
     '''
     Raises an exception if a == b
     @param a
@@ -79,7 +79,7 @@ def validateNotEqual(a,b,message='',exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateFalse(conditional, message='', exception=None):
+def validate_false(conditional, message='', exception=None):
     '''
     Raises an exception if conditional evaluates to False
     @param conditional The conditional statement to be evaluated
@@ -91,7 +91,7 @@ def validateFalse(conditional, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateIs(a,b, message='', exception=None):
+def validate_is(a,b, message='', exception=None):
     '''
     Raises an exception if a does not points to the same object as b
     @param a
@@ -104,7 +104,7 @@ def validateIs(a,b, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateIsNot(a,b, message='', exception=None):
+def validate_is_not(a,b, message='', exception=None):
     '''
     Raises an exception if a points to the same object as b
     @param a
@@ -117,7 +117,7 @@ def validateIsNot(a,b, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateIsNotNone(conditional, message='', exception=None):
+def validate_is_not_none(conditional, message='', exception=None):
     '''
     Raises an exception if conditional is None, does not point to anything and is not a number.
     @param conditional The conditional statement to be evaluated
@@ -130,7 +130,7 @@ def validateIsNotNone(conditional, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateIn(needle,haystack, message='', exception=None):
+def validate_in(needle,haystack, message='', exception=None):
     '''
     Raises an exception if needle is not in haystack
     @param needle Item to be evaluated for
@@ -143,7 +143,7 @@ def validateIn(needle,haystack, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateNotIn(needle,haystack, message='', exception=None):
+def validate_not_in(needle,haystack, message='', exception=None):
     '''
     Raises an exception if needle is in haystack
     @param needle Item to be evaluated for
@@ -156,7 +156,7 @@ def validateNotIn(needle,haystack, message='', exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateIsInstance(a,cls,message='',exception=None):
+def validate_is_instance(a,cls,message='',exception=None):
     '''
     Raises an exception if a is not an instance of cls
     @param a Object
@@ -169,7 +169,7 @@ def validateIsInstance(a,cls,message='',exception=None):
         name,l = scoped_validation()
         ArgCheck(name,exception).validation(False,message,l)
 
-def validateNotIsInstance(a,cls, message='', exception=None):
+def validate_not_is_instance(a,cls, message='', exception=None):
     '''
     Raises an exception if a is an instance of cls
     @param a Object

--- a/pyon/util/test/test_arg_check.py
+++ b/pyon/util/test/test_arg_check.py
@@ -25,55 +25,55 @@ class ArgCheckTest(PyonTestCase):
         import pyon.util.arg_check as arg_check
 
         with self.assertRaises(BadRequest):
-            arg_check.validateTrue(False,'test')
+            arg_check.validate_true(False,'test')
 
         with self.assertRaises(BadRequest):
-            arg_check.validateEqual(3,4,'test')
+            arg_check.validate_equal(3,4,'test')
 
         with self.assertRaises(BadRequest):
-            arg_check.validateNotEqual(4,4,'test')
+            arg_check.validate_not_equal(4,4,'test')
 
         with self.assertRaises(BadRequest):
-            arg_check.validateFalse(True,'test')
+            arg_check.validate_false(True,'test')
 
         with self.assertRaises(BadRequest):
             one = list()
             two = list()
-            arg_check.validateIs(one,two,'test')
+            arg_check.validate_is(one,two,'test')
 
         with self.assertRaises(BadRequest):
             one = list()
             two = one
-            arg_check.validateIsNot(one,two,'test')
+            arg_check.validate_is_not(one,two,'test')
 
         with self.assertRaises(BadRequest):
             c = None
-            arg_check.validateIsNotNone(c,'test')
+            arg_check.validate_is_not_none(c,'test')
 
         with self.assertRaises(BadRequest):
             one = list([1,3])
             two = 2
-            arg_check.validateIn(two,one,'test')
+            arg_check.validate_in(two,one,'test')
 
         with self.assertRaises(BadRequest):
             one = list([1,2,3])
             two = 2
-            arg_check.validateNotIn(two,one,'test')
+            arg_check.validate_not_in(two,one,'test')
 
         with self.assertRaises(BadRequest):
             one = list()
-            arg_check.validateIsInstance(one,dict,'test')
+            arg_check.validate_is_instance(one,dict,'test')
 
         with self.assertRaises(BadRequest):
             one = list()
-            arg_check.validateNotIsInstance(one,list,'test')
+            arg_check.validate_not_is_instance(one,list,'test')
 
     def test_validates_success(self):
         import pyon.util.arg_check as ac
         fl = self._FakeLog()
         ac.log = fl
         try:
-            ac.validateTrue(False,'blah')
+            ac.validate_true(False,'blah')
         except BadRequest as e:
             self.assertTrue(e.message == 'blah')
 


### PR DESCRIPTION
Changes the arg_check method wrappers to use PEP8 convention for method names in lieu of `unittest.TestCase` convention.

To make Pyon-safe assertions about conditionals

```
from pyon.util.arg_check import validate_is_true, validate_is_instance

validate_is_true(a, "A is not true.")

validate_is_instance(my_list,list,"My list is not a list.")
```
