### PR TITLE
ION Process context flow of execution

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -185,7 +185,7 @@ class Container(BaseContainerAgent):
         rsvc = ProcessRPCServer(node=self.node, from_name=self.name, service=self, process=self)
 
         # Start an ION process with the right kind of endpoint factory
-        proc = self.proc_manager.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=rsvc)
+        proc = self.proc_manager.proc_sup.spawn((CFG.cc.proctype or 'green', None), listeners=[rsvc])
         self.proc_manager.proc_sup.ensure_ready(proc)
         self._capabilities.append("CONTAINER_AGENT")
 

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -341,7 +341,7 @@ class ProcManager(object):
                                 service=service_instance,
                                 process=service_instance)
         # Start an ION process with the right kind of endpoint factory
-        proc = self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=rsvc, name=listen_name,
+        proc = self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listeners=[rsvc], name=listen_name,
                                     proc_name=service_instance._proc_name)
         self.proc_sup.ensure_ready(proc, "_set_service_endpoint for listen_name: %s" % listen_name)
 
@@ -358,7 +358,7 @@ class ProcManager(object):
         sub = service_instance.stream_subscriber_registrar.create_subscriber(exchange_name=listen_name,callback=lambda m,h: service_instance.call_process(m))
 
 
-        proc = self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listener=sub, name=listen_name,
+        proc = self.proc_sup.spawn((CFG.cc.proctype or 'green', None), listeners=[sub], name=listen_name,
                                     proc_name=service_instance._proc_name)
         self.proc_sup.ensure_ready(proc, '_set_subscription_endpoint for listen_name: %s' % listen_name)
 
@@ -405,8 +405,8 @@ class ProcManager(object):
 
         # find the proc
         lp = list(self.proc_sup.children)
-        lps = [p for p in lp if p.listener._process == service_instance]
-
+        lps = set()
+        map(lambda p: lps.add, (p for p in lp if service_instance in (l._process for l in p.listeners)))
 
         for p in lps:
             p.notify_stop()

--- a/pyon/core/process.py
+++ b/pyon/core/process.py
@@ -10,7 +10,6 @@ from pyon.util.log import log
 from pyon.core.exception import ContainerError
 
 import time
-import multiprocessing as mp
 import os
 import signal
 
@@ -136,34 +135,6 @@ class GreenProcess(PyonProcess):
         ev.set()
         return ev
 
-class PythonProcess(PyonProcess):
-    """
-    @brief A BaseProcess that uses a full OS process to do its work.
-    """
-
-    def _pid(self):
-        return self.proc.pid
-
-    def _spawn(self):
-        # Multiprocessing spawn
-        proc = mp.Process(target=self.target, args=self.spawn_args, kwargs=self.spawn_kwargs)
-        proc.daemon = True
-        proc.start()
-        return proc
-
-    def _join(self, timeout=None):
-        return self.proc.join(timeout)
-
-    def _stop(self):
-        return self.proc.terminate()
-
-    def _running(self):
-        return self.proc.is_alive()
-
-    def get_ready_event(self):
-        log.warn("get ready event not implemented for PythonProcess")
-        return None
-
 class ProcessSupervisor(object):
     """
     @brief Manage spawning processes of multiple kinds and ensure they're alive.
@@ -172,7 +143,7 @@ class ProcessSupervisor(object):
 
     type_callables = {
           'green': GreenProcess
-        , 'python': PythonProcess
+#        , 'python': PythonProcess
     }
 
     def __init__(self, heartbeat_secs=10.0, failure_notify_callback=None):
@@ -236,10 +207,6 @@ class ProcessSupervisor(object):
         @param  timeout     Amount of time (in seconds) to wait for the ready, default 10 seconds.
         @throws ContainerError  If the process dies or if we get a timeout before the process signals ready.
         """
-
-        if isinstance(proc, PythonProcess):
-            log.warn("ensure_ready does not yet work on PythonProcesses")
-            return True
 
         if not errmsg:
             errmsg = "ensure_ready failed"

--- a/pyon/core/test/test_process.py
+++ b/pyon/core/test/test_process.py
@@ -3,16 +3,17 @@
 __author__ = 'Adam R. Smith'
 __license__ = 'Apache 2.0'
 
-from pyon.core.process import GreenProcess, PythonProcess, GreenProcessSupervisor
+from pyon.core.process import GreenProcess, GreenProcessSupervisor
 from pyon.core.exception import ContainerError
 from pyon.util.int_test import IonIntegrationTestCase
+from pyon.util.unit_test import PyonTestCase
 from unittest import SkipTest
 from nose.plugins.attrib import attr
 
 import time
 
 @attr('UNIT', group='process')
-class ProcessTest(IonIntegrationTestCase):
+class ProcessTest(PyonTestCase):
     def setUp(self):
         self.counter = 0
 
@@ -70,15 +71,6 @@ class ProcessTest(IonIntegrationTestCase):
         elapsed = sup.shutdown()
         self.assertLess(elapsed - proc_sleep_secs, 0.2)
 
-    def test_python(self):
-        raise SkipTest('Need a better test here')
-        self.counter = 0
-        proc = PythonProcess(self.increment, 2)
-        proc.start()
-        self.assertEqual(self.counter, 0)
-        proc.join()
-        self.assertEqual(self.counter, 2)
-
     def test_ensure_ready(self):
         # GreenProcess by default will signal ready immediately, but we can still pass it through to make sure it's ok
         sup = GreenProcessSupervisor()
@@ -115,6 +107,5 @@ class ProcessTest(IonIntegrationTestCase):
 
         proc = sup.spawn(('green', failboat))
         self.assertRaises(ContainerError, sup.ensure_ready, proc)
-
 
 

--- a/pyon/ion/process.py
+++ b/pyon/ion/process.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 
+
 __author__ = 'Adam R. Smith, Michael Meisinger'
 __license__ = 'Apache 2.0'
-
-import threading
 
 from pyon.util.log import log
 from pyon.core.process import GreenProcess, PythonProcess, GreenProcessSupervisor
 from pyon.net import messaging, endpoint
 from pyon.service.service import BaseService
+from gevent.event import Event, waitall
+from gevent.queue import Queue
+import time
+from pyon.util.async import wait, spawn
+import threading
 
 class IonProcessBase(object):
     """
@@ -16,28 +20,73 @@ class IonProcessBase(object):
     Just add greenlets or python processes to complete.
     """
 
-    def __init__(self, listener=None, name=None):
-        self.listener   = listener
-        self.name       = name
+    def __init__(self, listeners=None, name=None, routing_obj=None):
+        self.listeners      = listeners
+        self.name           = name
+        self.routing_obj    = routing_obj       # where the requests go
+        self._child_procs   = []
+        self._ctrl_queue    = Queue()
+
+    def _child_failed(self, child):
+        """
+        Occurs when any child greenlet fails.
+
+        Propogates the error up to the process supervisor.
+        """
+        self.proc.throw(child.value)
 
     def target(self, *args, **kwargs):
-        """ Control entrypoint. Setup the base properties for this process (mainly a listener)."""
+        """
+        Control entrypoint. Setup the base properties for this process (mainly a listener).
+        """
         if self.name:
             threading.current_thread().name = self.name
-        self.listener.listen()
+
+        for listener in self.listeners:
+            self._child_procs.append(spawn(listener.listen))
+
+        # spawn control flow loop
+        self._child_procs.append(spawn(self._control_flow))
+
+        # link them all to a failure handler
+        map(lambda x: x.link_exception(self._child_failed), self._child_procs)
+
+        # wait on them
+        self._wait_children()
+
+    def _control_flow(self):
+        for call in self._ctrl_queue:
+            # @TODO!
+            pass
 
     def _notify_stop(self):
-        self.listener.close()
+        map(lambda x: x.close(), self.listeners)
+        self._ctrl_queue.put(StopIteration)
+
+        self._wait_children()
+
         super(IonProcessBase, self)._notify_stop()
+
+    def _wait_children(self):
+        pass
 
 class GreenIonProcess(IonProcessBase, GreenProcess):
 
-    def __init__(self, target=None, listener=None, name=None, *args, **kwargs):
-        IonProcessBase.__init__(self, listener=listener, name=name)
-        GreenProcess.__init__(self, target=target, *args, **kwargs)
+    def __init__(self, target=None, listeners=None, name=None, **kwargs):
+        IonProcessBase.__init__(self, listeners=listeners, name=name)
+        GreenProcess.__init__(self, target=target, **kwargs)
 
     def get_ready_event(self):
-        return self.listener.get_ready_event()
+        ev = Event()
+        def allready(ev):
+            waitall([x.get_ready_event() for x in self.listeners])
+            ev.set()
+
+        spawn(allready, ev)
+        return ev
+
+    def _wait_children(self):
+        wait(self._child_procs)
 
 class PythonIonProcess(IonProcessBase, PythonProcess):
     pass

--- a/pyon/ion/process.py
+++ b/pyon/ion/process.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python
 
 
-__author__ = 'Adam R. Smith, Michael Meisinger'
+__author__ = 'Adam R. Smith, Michael Meisinger, Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
 
 from pyon.util.log import log
-from pyon.core.process import GreenProcess, PythonProcess, GreenProcessSupervisor
-from pyon.net import messaging, endpoint
+from pyon.core.process import GreenProcess, GreenProcessSupervisor
 from pyon.service.service import BaseService
-from gevent.event import Event, waitall
+from gevent.event import Event, waitall, AsyncResult
 from gevent.queue import Queue
-import time
+from gevent import greenlet
 from pyon.util.async import wait, spawn
 import threading
 
-class IonProcessBase(object):
+class GreenIonProcess(GreenProcess):
     """
     Form the base of an ION process.
     Just add greenlets or python processes to complete.
     """
 
-    def __init__(self, listeners=None, name=None, routing_obj=None):
+    def __init__(self, target=None, listeners=None, name=None, **kwargs):
         self.listeners      = listeners
         self.name           = name
-        self.routing_obj    = routing_obj       # where the requests go
         self._child_procs   = []
         self._ctrl_queue    = Queue()
+
+        GreenProcess.__init__(self, target=target, **kwargs)
 
     def _child_failed(self, child):
         """
@@ -33,7 +33,7 @@ class IonProcessBase(object):
 
         Propogates the error up to the process supervisor.
         """
-        self.proc.throw(child.value)
+        self.proc.throw(child.exception)
 
     def target(self, *args, **kwargs):
         """
@@ -42,7 +42,10 @@ class IonProcessBase(object):
         if self.name:
             threading.current_thread().name = self.name
 
+        # - tell all listeners they need to call here for sync
+        # - spawn listen loops
         for listener in self.listeners:
+            listener.routing_call = self._routing_call
             self._child_procs.append(spawn(listener.listen))
 
         # spawn control flow loop
@@ -52,31 +55,67 @@ class IonProcessBase(object):
         map(lambda x: x.link_exception(self._child_failed), self._child_procs)
 
         # wait on them
-        self._wait_children()
+        wait(self._child_procs)
+
+    def _routing_call(self, call, callargs):
+        """
+        Endpoints call into here to synchronize across the entire IonProcess.
+
+        Returns immediately with an AsyncResult that can be waited on. Calls
+        are made by the loop in _control_flow. We pass in the calling greenlet so
+        exceptions are raised in the correct context.
+        """
+        ar = AsyncResult()
+
+        self._ctrl_queue.put((greenlet.getcurrent(), ar, call, callargs))
+        return ar
 
     def _control_flow(self):
-        for call in self._ctrl_queue:
-            # @TODO!
-            pass
+        """
+        Main process thread of execution method.
+
+        This method is run inside a greenlet and exists for each ION process. Listeners
+        attached to the process, either RPC Servers or Subscribers, synchronize their calls
+        by placing future calls into the queue by calling _routing_call.  This is all done
+        automatically for you by the Container's Process Manager.
+
+        This method blocks until there are calls to be made in the synchronized queue, and
+        then calls from within this greenlet.  Any exception raised is caught and re-raised
+        in the greenlet that originally scheduled the call.  If successful, the AsyncResult
+        created at scheduling time is set with the result of the call.
+        """
+        for calltuple in self._ctrl_queue:
+            calling_gl, ar, call, callargs = calltuple
+            log.debug("control_flow making call: %s %s", call, callargs)
+
+            res = None
+            try:
+                res = call(**callargs)
+            except Exception as e:
+                # raise the exception in the calling greenlet, and don't
+                # wait for it to die - it's likely not going to do so.
+                calling_gl.kill(exception=e, block=False)
+
+            ar.set(res)
 
     def _notify_stop(self):
+        """
+        Called when the process is about to be shut down.
+
+        Instructs all listeners to close, puts a StopIteration into the synchronized queue,
+        and waits for the listeners to close and for the control queue to exit.
+        """
         map(lambda x: x.close(), self.listeners)
         self._ctrl_queue.put(StopIteration)
 
-        self._wait_children()
+        wait(self._child_procs)
 
-        super(IonProcessBase, self)._notify_stop()
-
-    def _wait_children(self):
-        pass
-
-class GreenIonProcess(IonProcessBase, GreenProcess):
-
-    def __init__(self, target=None, listeners=None, name=None, **kwargs):
-        IonProcessBase.__init__(self, listeners=listeners, name=name)
-        GreenProcess.__init__(self, target=target, **kwargs)
+        GreenProcess._notify_stop(self)
 
     def get_ready_event(self):
+        """
+        Returns an Event that is set when all the listeners in this Process are running.
+        """
         ev = Event()
         def allready(ev):
             waitall([x.get_ready_event() for x in self.listeners])
@@ -85,16 +124,10 @@ class GreenIonProcess(IonProcessBase, GreenProcess):
         spawn(allready, ev)
         return ev
 
-    def _wait_children(self):
-        wait(self._child_procs)
-
-class PythonIonProcess(IonProcessBase, PythonProcess):
-    pass
-
 class IonProcessSupervisor(GreenProcessSupervisor):
     type_callables = {
           'green': GreenIonProcess
-        , 'python': PythonIonProcess
+#        , 'python': PythonIonProcess
     }
 
 # ---------------------------------------------------------------------------------------------------

--- a/pyon/ion/test/test_process.py
+++ b/pyon/ion/test/test_process.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+from pyon.util.async import wait
+
+__author__ = 'Dave Foster <dfoster@asascience.com>'
+__license__ = 'Apache 2.0'
+
+from mock import sentinel, Mock
+from nose.plugins.attrib import attr
+from pyon.ion.process import GreenIonProcess
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.net.endpoint import ProcessRPCServer
+from gevent.event import AsyncResult
+from gevent.coros import Semaphore
+from pyon.util.unit_test import PyonTestCase
+import time
+
+@attr('UNIT', group='process')
+class ProcessTest(PyonTestCase):
+
+    class ExpectedFailure(StandardError):
+        pass
+
+    def test_spawn_proc_with_no_listeners(self):
+        p = GreenIonProcess(name=sentinel.name, listeners=[])
+        p.start()
+        p.get_ready_event().wait(timeout=5)
+
+        self.assertEquals(len(p._child_procs), 1)
+
+        p._notify_stop()
+
+        self.assertTrue(p._child_procs[0].dead)
+
+        p.stop()
+
+    def test_spawn_proc_with_one_listener(self):
+        mocklistener = Mock(spec=ProcessRPCServer)
+        p = GreenIonProcess(name=sentinel.name, listeners=[mocklistener])
+        p.start()
+        p.get_ready_event().wait(timeout=5)
+
+        self.assertEquals(len(p._child_procs), 2)
+        mocklistener.listen.assert_called_once_with()
+        self.assertEqual(mocklistener.routing_call, p._routing_call)
+
+        p._notify_stop()
+
+        mocklistener.close.assert_called_once_with()
+
+        p.stop()
+
+    def test_spawn_with_listener_failure(self):
+        mocklistener = Mock(spec=ProcessRPCServer)
+        mocklistener.listen.side_effect = self.ExpectedFailure
+        p = GreenIonProcess(name=sentinel.name, listeners=[mocklistener])
+        p.start()
+        p.get_ready_event().wait(timeout=5)
+
+        # the exception is linked to the main proc inside the IonProcess, so that should be dead now
+        self.assertTrue(p.proc.dead)
+        self.assertIsInstance(p.proc.exception, StandardError)
+
+        # stopping will raise an error as proc died already
+        self.assertRaises(self.ExpectedFailure, p._notify_stop)
+
+        # make sure control flow proc died though
+        self.assertTrue(p._child_procs[-1].dead)
+
+        p.stop()
+
+    def test__routing_call(self):
+        p = GreenIonProcess(name=sentinel.name, listeners=[])
+        p.start()
+        p.get_ready_event().wait(timeout=5)
+
+        ar = AsyncResult()
+        p._routing_call(ar.set, {'value':sentinel.callarg})
+
+        v = ar.get(timeout=5)
+        self.assertEquals(v, sentinel.callarg)
+
+        p._notify_stop()
+        p.stop()
+
+    def test_competing__routing_call(self):
+        p = GreenIonProcess(name=sentinel.name, listeners=[])
+        p.start()
+        p.get_ready_event().wait(timeout=5)
+
+        sem = Semaphore()
+
+        # define a callable method that tries to grab a shared semaphore
+        def thecall(ar=None):
+
+            semres = sem.acquire(blocking=False)
+            if not semres:
+                raise StandardError("Could not get semaphore, routing_call/control flow is broken!")
+
+            # make this take a sec
+            time.sleep(1)
+
+            # make sure we release
+            sem.release()
+
+            # set the ar
+            ar.set(True)
+
+        # schedule some calls (in whatever order)
+        ar1 = AsyncResult()
+        ar2 = AsyncResult()
+        ar3 = AsyncResult()
+
+        p._routing_call(thecall, {'ar':ar3})
+        p._routing_call(thecall, {'ar':ar1})
+        p._routing_call(thecall, {'ar':ar2})
+
+        # wait on all the ARs to be set
+        wait([ar1, ar2, ar3])
+
+        # just getting here without throwing an exception is the true test!
+
+        p._notify_stop()
+        p.stop()
+
+
+

--- a/pyon/ion/transform.py
+++ b/pyon/ion/transform.py
@@ -172,7 +172,7 @@ class TransformBenchTesting(TransformDataProcess):
             pids += 1
 
     def on_start(self):
-        TransformDataProcess.__init__(self)
+        TransformDataProcess.on_start(self)
 
         # set up subscriber to *
         self._bt_sub = Subscriber(callback=lambda m, h: self.call_process(m),

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -175,6 +175,7 @@ class EndpointUnit(object):
                     msg, headers, delivery_tag = self.channel.recv()
                     log.debug("client_recv got a message")
                     log_message(self.channel._send_name , msg, headers, delivery_tag)
+
                     try:
                         self._message_received(msg, headers)
                     finally:
@@ -952,10 +953,10 @@ class RPCResponseEndpointUnit(ResponseEndpointUnit):
             ######
             ###### THIS IS WHERE THE SERVICE OPERATION IS CALLED ######
             ######
-            result = ro_meth(**cmd_arg_obj)
+            result              = self._make_routing_call(ro_meth, cmd_arg_obj)
+            response_headers    = { 'status_code': 200, 'error_message': '' }
             ######
 
-            response_headers = { 'status_code': 200, 'error_message': '' }
         except TypeError as ex:
             log.exception("TypeError while attempting to call routing object's method")
             response_headers = self._create_error_response(ServerError(ex.message))
@@ -967,6 +968,15 @@ class RPCResponseEndpointUnit(ResponseEndpointUnit):
         return {'status_code': ex.get_status_code(),
                 'error_message': str(ex.get_error_message()),
                 'performative':'failure'}
+
+    def _make_routing_call(self, call, op_args):
+        """
+        Calls into the routing object.
+
+        May be overridden at a lower level.
+        """
+        return call(**op_args)
+
 
 class RPCServer(RequestResponseServer):
     endpoint_unit_type = RPCResponseEndpointUnit
@@ -1113,9 +1123,10 @@ class ProcessRPCClient(RPCClient):
 
 
 class ProcessRPCResponseEndpointUnit(ProcessEndpointUnitMixin, RPCResponseEndpointUnit):
-    def __init__(self, process=None, **kwargs):
+    def __init__(self, process=None, routing_call=None, **kwargs):
         ProcessEndpointUnitMixin.__init__(self, process=process)
         RPCResponseEndpointUnit.__init__(self, **kwargs)
+        self._routing_call = routing_call
 
     def _message_received(self, msg, headers):
         """
@@ -1141,15 +1152,33 @@ class ProcessRPCResponseEndpointUnit(ProcessEndpointUnitMixin, RPCResponseEndpoi
 
         return header1
 
+    def _make_routing_call(self, call, op_args):
+        if not self._routing_call:
+            return RPCResponseEndpointUnit._make_routing_call(self, call, op_args)
+
+        ar = self._routing_call(call, op_args)
+        return ar.get()     # @TODO: timeout?
+
+
 class ProcessRPCServer(RPCServer):
     endpoint_unit_type = ProcessRPCResponseEndpointUnit
 
-    def __init__(self, process=None, **kwargs):
+    def __init__(self, process=None, routing_call=None, **kwargs):
         assert process
         self._process = process
+        self._routing_call = routing_call
         RPCServer.__init__(self, **kwargs)
+
+    @property
+    def routing_call(self):
+        return self._routing_call
+
+    @routing_call.setter
+    def routing_call(self, value):
+        self._routing_call = value
 
     def create_endpoint(self, **kwargs):
         newkwargs = kwargs.copy()
         newkwargs['process'] = self._process
+        newkwargs['routing_call'] = self._routing_call
         return RPCServer.create_endpoint(self, **newkwargs)

--- a/pyon/net/test/test_endpoint.py
+++ b/pyon/net/test/test_endpoint.py
@@ -1039,9 +1039,10 @@ class TestProcessRPCServer(PyonTestCase):
     @patch('pyon.net.endpoint.RPCServer.create_endpoint')
     def test_create_endpoint(self, mockce):
         prps = ProcessRPCServer(process=sentinel.process)
+        prps.routing_call = sentinel.rcall
         prps.create_endpoint(to_name=sentinel.to_name)
 
-        mockce.assert_called_once_with(prps, process=sentinel.process, to_name=sentinel.to_name)
+        mockce.assert_called_once_with(prps, process=sentinel.process, to_name=sentinel.to_name, routing_call=sentinel.rcall)
 
 
 

--- a/pyon/public.py
+++ b/pyon/public.py
@@ -27,8 +27,8 @@ __all__ += ['ionprint']
 from pyon.util.async import spawn, switch
 __all__ += ['spawn', 'switch']
 
-from pyon.core.process import PyonProcessError, GreenProcess, GreenProcessSupervisor, PythonProcess
-__all__ += ['PyonProcessError', 'GreenProcess', 'GreenProcessSupervisor', 'PythonProcess']
+from pyon.core.process import PyonProcessError, GreenProcess, GreenProcessSupervisor
+__all__ += ['PyonProcessError', 'GreenProcess', 'GreenProcessSupervisor']
 
 from pyon.core import exception as iex
 __all__ += ['iex']


### PR DESCRIPTION
- Container API refactored to allow multiple listeners to one IonProcess
- Listeners call into the service in a synchronized, safe fashion
- Error handling warped around to the correct calling greenlets
- Unit tests which cover the majority of usages

There will be some small cleanup to do afterwards - the ProcessSupervisor classes can be simplified a bit now that PythonProcess and friends are removed, but they are minor and unrelated to the main work here.

TBR @mmeisinger
