### PR TITLE
`DotDict` Extension

### DIFF
--- a/pyon/util/containers.py
+++ b/pyon/util/containers.py
@@ -56,18 +56,29 @@ class DotDict(DotNotationGetItem, dict):
     """
 
     def __dir__(self):
-        dictdir = dir(dict(self))       # woof, this is slow, but a rarely called method anyway, really for interactive work
-        dictdir.extend(self.iterkeys())
-        return dictdir
+        return self.__dict__.keys() + self.keys()
 
     def __getattr__(self, key):
         """ Make attempts to lookup by nonexistent attributes also attempt key lookups. """
-        try:
-            val = self.__getitem__(key)
-        except KeyError:
-            raise AttributeError(key)
+        if self.has_key(key):
+            return self[key]
+        import sys
+        import dis
+        frame = sys._getframe(1)
+        if '\x00%c' % dis.opmap['STORE_ATTR'] in frame.f_code.co_code:
+            self[key] = DotDict()
+            return self[key]
 
-        return val
+        raise AttributeError(key)
+
+    def __setattr__(self,key,value):
+        if hasattr(self,key):
+            raise AttributeError('%s conflicts with builtin.' % key)
+        if isinstance(value, dict):
+            self[key] = DotDict(value)
+        else:
+            self[key] = value
+
 
     def copy(self):
         return DotDict(dict.copy(self))
@@ -93,7 +104,7 @@ class DictModifier(DotDict):
             data = DotDict(data)
         elif not isinstance(base, DotDict):
             raise TypeError("Base must be of type DotDict")
-        self.base = base
+        dict.__setattr__(self,'base',base)
 
         if data is not None:
             self.update(data)

--- a/pyon/util/test/test_containers.py
+++ b/pyon/util/test/test_containers.py
@@ -43,5 +43,35 @@ class Test_Containers(IonIntegrationTestCase):
         self.assertEqual(dict_modifier["bah"], "trah")
         self.assertEqual(dict_modifier["doh"], "ray")
 
+    def test_dotdict_chaining(self):
+        base = DotDict({'test':None})
+        base.chained.example.provides.utility = True
+        self.assertTrue(base['chained']['example']['provides']['utility'])
+        base.setting = True
+        self.assertTrue(base.setting)
+        self.assertTrue(base['setting'])
+
+        base.map = {'key':'value'}
+        self.assertIsInstance(base.map,DotDict, '%s' % type(base.map))
+        self.assertTrue(base.map.key=='value')
+
+    def test_dotdict_error(self):
+        base = DotDict()
+        with self.assertRaises(AttributeError):
+            test_case = base.non_existent
+        with self.assertRaises(KeyError):
+            base['non_existent']
+
+    def test_dotdict_builtin_error(self):
+        # Ensures that you can not override the builtin methods
+        base = DotDict()
+        with self.assertRaises(AttributeError):
+            base.pop = 'shouldnt work'
+        with self.assertRaises(AttributeError):
+            base.__getitem__ = 'really shouldnt work'
+
+        with self.assertRaises(AttributeError):
+            base.another.chained.pop = 'again should not work'
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds extension to `DotDict` 

Capabilities:
- Set attributes using Dot Notation

```
config = DotDict()
config.server_name = 'couch'
```
- Set attributes using chained Dot Notation

```
config = DotDict()
config.server.name = 'couch'
config.server.hostname = 'localhost'
config.server.port = '5984'
config.logging.verbose.failures = False
config.logging.verbose.exceptions = True
```
- Protection from overriding builtin methods

```
config = DotDict()
config.pop = 'Popped'
--> AttributeError: pop conflicts with builtin.
config.chained.attrs.pop = 'Popped'
--> AttributeError: pop conflicts with builtin.
```
- Unit Tests for new functionality
