### PR TITLE
Include xml files in eggs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(  name = 'pyon',
             'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler'
         ],
         test_suite = 'pyon',
+        package_data = {'': ['*.xml']},
         install_requires = [
             # Patched greenlet to work on ARMS
             'greenlet==0.3.1-p1',


### PR DESCRIPTION
Right now the production buildout config installs pyon as an egg (rather than with setup.py develop style deployment), and it doesn't include xml files in that egg. This causes problems with empty_policy_set.xml in one of the bootstrap levels in r2deploy.

This patch includes xml files in generated eggs.
