### PR TITLE
Taxytool eq

### DIFF
--- a/pyon/ion/granule/taxonomy.py
+++ b/pyon/ion/granule/taxonomy.py
@@ -235,5 +235,20 @@ class TaxyTool(object):
 
         return cls(t)
 
+    def __eq__(self, other):
+
+        if self is other:
+            return True
+
+        if not isinstance(other, TaxyTool):
+            return False
+
+        if self._t is other._t:
+            return True
+
+        if self._t.map == other._t.map:
+            return True
+
+        return False
 
 

--- a/pyon/ion/granule/test/test_record_dictionary.py
+++ b/pyon/ion/granule/test/test_record_dictionary.py
@@ -24,6 +24,7 @@ class RecordDictionaryToolTestCase(unittest.TestCase):
         self._tx.add_taxonomy_set('cond', 'long_cond_name')
         self._tx.add_taxonomy_set('pres', 'long_pres_name')
         self._tx.add_taxonomy_set('rdt')
+        self._tx.add_taxonomy_set('rdt2')
         # map is {<local name>: <granule name or path>}
 
         self._rdt = RecordDictionaryTool(taxonomy=self._tx)
@@ -72,15 +73,22 @@ class RecordDictionaryToolTestCase(unittest.TestCase):
         self.assertTrue(numpy.allclose(self._rdt['pres'], pres_array))
 
         #want to check to make sure a KeyError is raised when a non-nickname key is used, but it's not working correctly
-        #self.assertRaises(KeyError, numpy.allclose(self._rdt['long_temp_name']))
-        #self.assertRaises(KeyError, self._rdt['long_cond_name'])
-        #self.assertRaises(KeyError, self._rdt['long_pres_name'])
+        self.assertRaises(KeyError, self._rdt.__getitem__, 'long_temp_name')
+        self.assertRaises(KeyError, self._rdt.__getitem__,'nonsense!')
 
-        # map is {<local name>: <granule name or path>}
-
-        rdt = RecordDictionaryTool(taxonomy=self._tx)
-        rdt['rdt'] = temp_array
+        taxy_tool_obj =self._tx
+        rdt = RecordDictionaryTool(taxonomy=taxy_tool_obj)
+        rdt['temp'] = temp_array
         self._rdt['rdt'] = rdt
+
+        # Now test when the Record Dictionary Tool is created with the Taxonomy object rather than the TaxyTool
+        # This can fail if the == method for TaxyTool is implemented incorrectly
+
+        taxonomy_ion_obj = self._tx._t
+        rdt2 = RecordDictionaryTool(taxonomy=taxonomy_ion_obj)
+        rdt2['temp'] = temp_array
+        self._rdt['rdt2'] = rdt2
+
 
     def test_iteration(self):
         """

--- a/pyon/ion/granule/test/test_taxonomy.py
+++ b/pyon/ion/granule/test/test_taxonomy.py
@@ -36,6 +36,70 @@ class TaxonomyToolTestCase(unittest.TestCase):
         tc3 = TaxyTool(tx)
         self.assertEquals(tc3.get_names_by_handle(1),{'nick_name','a'})
 
+    def test_eq(self):
+
+        tx1 = Taxonomy(map={1:('nick_name',{'nick_name','a'}),
+                           2:('nick2',{'nick2','a','b','cc'})} )
+
+        # pass with tt1._t.map "is"
+        tt1 = TaxyTool(tx1)
+        tt2 = TaxyTool(tx1)
+        self.assertEquals(tt1, tt2)
+
+        # after changes - thy are still the same
+        tt2.add_taxonomy_set('new_name','p','q','r')
+        self.assertEquals(tt2,tt1)
+
+
+        # pass with 'is'
+        tt3 = tt1
+        self.assertEquals(tt3, tt1)
+
+        # after changes - thy are still the same
+        tt3.add_taxonomy_set('new_name','p','q','r')
+        self.assertEquals(tt1,tt3)
+
+
+        # pass with tt1._t.map '=='
+        tx1 = Taxonomy(map={1:('nick_name',{'nick_name','a'}),
+                            2:('nick2',{'nick2','a','b','cc'})} )
+
+        tx2 = Taxonomy(map={1:('nick_name',{'nick_name','a'}),
+                            2:('nick2',{'nick2','a','b','cc'})} )
+        self.assertNotEquals(tx1, tx2)
+        self.assertEquals(tx1.map, tx2.map)
+
+        tt1 = TaxyTool(tx1)
+        tt2 = TaxyTool(tx2)
+        self.assertEquals(tt1, tt2)
+
+        # fail with tt1._t.map '=='
+        tx2 = Taxonomy(map={1:('nick_name',{'nick_name','as'}),
+                            2:('nick2',{'nick2','a','b','cc'})} )
+        tt1 = TaxyTool(tx1)
+        tt2 = TaxyTool(tx2)
+        self.assertNotEquals(tt1, tt2)
+
+
+        # Use the interface to build a complex one and test equality as they go in and out of sync...
+        tt1 = TaxyTool()
+        tt2 = TaxyTool()
+        tt1.add_taxonomy_set('a name','junk','1','2')
+        tt2.add_taxonomy_set('a name','junk','1','2')
+
+        self.assertEquals(tt1, tt2)
+
+        tt2.add_taxonomy_set('new_name','1')
+
+        self.assertNotEquals(tt1,tt2)
+
+        tt1.extend_names_by_nick_name('a name','3')
+        tt2.extend_names_by_nick_name('a name','3')
+
+        tt1.add_taxonomy_set('new_name','1')
+
+        self.assertEquals(tt1, tt2)
+
 
     def test_taxonomy_set(self):
 


### PR DESCRIPTION
Added **eq** method for TaxyTool class.
Requested by Chris M.
Required because creating nested record dictionaries asserts that the taxonomy is equal which worked previously when the 'is' passed, but with the ability to create a record dictionary from a Taxonomy object directly a more rigorous test for equality of the TaxyTool is required.

David
