### PR TITLE
Allow multiple connections to brokers

### DIFF
--- a/pyon/container/test/test_cc.py
+++ b/pyon/container/test/test_cc.py
@@ -28,8 +28,27 @@ class TestCC(PyonTestCase):
         self.cc.stop.assert_called_once_with()
         osmock.kill.assert_called_once_with(osmock.getpid(), signal.SIGTERM)
 
+    def test_node_when_not_started(self):
+        self.assertEquals(self.cc.node, None)
+
+    def test_node_when_started(self):
+        self.cc._capabilities.append("EXCHANGE_MANAGER")
+        self.cc.ex_manager = Mock()
+
+        self.assertEquals(self.cc.node, self.cc.ex_manager.default_node)
+
 @attr('INT')
 class TestCCInt(IonIntegrationTestCase):
+
+    def test_start_hello(self):
+        # start a service over messaging
+        self._start_container()
+        cc_client = ContainerAgentClient(node=self.container.node, name=self.container.name)
+
+        p = cc_client.spawn_process('hello', 'examples.service.hello_service', 'HelloService')
+
+@attr('INT')
+class TestCCIntProcs(IonIntegrationTestCase):
 
     class ExpectedFailure(StandardError):
         pass
@@ -66,12 +85,4 @@ class TestCCInt(IonIntegrationTestCase):
 
         # verify things got called
         self.cc.stop.assert_called_once_with()
-
-    def test_start_hello(self):
-        # start a service over messaging
-        self._start_container()
-        cc_client = ContainerAgentClient(node=self.container.node, name=self.container.name)
-
-        p = cc_client.spawn_process('hello', 'examples.service.hello_service', 'HelloService')
-
 

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -142,7 +142,7 @@ class ExchangeManager(object):
         log.debug("ExchangeManager.stopping (%d connections)", len(self._nodes))
 
         for name in self._nodes:
-            self._nodes[name].client.close()
+            self._nodes[name].stop_node()
             self._ioloops[name].kill()
             self._nodes[name].client.ioloop.start()     # loop until connection closes
 

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -17,6 +17,7 @@ from interface.services.coi.iexchange_management_service import ExchangeManageme
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceProcessClient
 from pyon.util.config import CFG
 from pyon.ion.resource import RT
+import time
 
 ION_URN_PREFIX = "urn:ionx"
 
@@ -25,10 +26,16 @@ ION_ROOT_XS = "ioncore"
 def valid_xname(name):
     return name and str(name).find(":") == -1 and str(name).find(" ") == -1
 
+class ExchangeManagerError(StandardError):
+    pass
+
 class ExchangeManager(object):
     """
     Manager object for the CC to manage Exchange related resources.
     """
+
+    NODE_PREFIX = "amqp"
+
     def __init__(self, container):
         log.debug("ExchangeManager initializing ...")
         self.container = container
@@ -61,7 +68,94 @@ class ExchangeManager(object):
         self._ems_client    = ExchangeManagementServiceProcessClient(process=self.container)
         self._rr_client     = ResourceRegistryServiceProcessClient(process=self.container)
 
-        # TODO: Do more initializing here, not in container
+        # mapping of node/ioloop runner by connection name (in config, filtered by NODE_PREFIX)
+        self._nodes     = {}
+        self._ioloops   = {}
+
+        self._client    = None
+        self._transport = None
+
+    def start(self):
+        log.debug("ExchangeManager.start")
+
+        total_count = 0
+
+        def handle_failure(name, node):
+            log.warn("Node %s could not be started", name)
+            node.ready.set()        # let it fall out below
+
+        # Establish connection(s) to broker
+        for name in CFG.server.iterkeys():
+            if name.startswith(self.NODE_PREFIX):
+                total_count += 1
+                log.debug("Starting connection: %s", name)
+
+                # start it with a zero timeout so it comes right back to us
+                node, ioloop = messaging.make_node(CFG.server[name], name, 0)
+
+                # install a finished handler directly on the ioloop just for this startup period
+                fail_handle = lambda _: handle_failure(name, node)
+                ioloop.link(fail_handle)
+
+                # wait for the node ready event, with a large timeout just in case
+                node_ready = node.ready.wait(timeout=15)
+
+                # remove the finished handler, we don't care about it here
+                ioloop.unlink(fail_handle)
+
+                # only add to our list if we started successfully
+                if not node.running:
+                    ioloop.kill()      # make sure ioloop dead
+                else:
+                    self._nodes[name]   = node
+                    self._ioloops[name] = ioloop
+
+        fail_count = total_count - len(self._nodes)
+        if fail_count > 0 or total_count == 0:
+            if fail_count == total_count:
+                raise ExchangeManagerError("No node connection was able to start (%d nodes attempted, %d nodes failed)" % (total_count, fail_count))
+
+            log.warn("Some nodes could not be started, ignoring for now")   # @TODO change when ready
+
+        self._transport = AMQPTransport.get_instance()
+        self._client    = self._get_channel(self._nodes.values()[0])        # @TODO
+
+        log.debug("Started %d connections (%s)", len(self._nodes), ",".join(self._nodes.iterkeys()))
+
+        # Declare root exchange
+        #self.default_xs.ensure_exists(self._get_channel())
+
+    def stop(self, *args, **kwargs):
+        # ##############
+        # HACK HACK HACK
+        #
+        # It appears during shutdown that when a channel is closed, it's not FULLY closed by the pika connection
+        # until the next round of _handle_events. We have to yield here to let that happen, in order to have close
+        # work fine without blowing up.
+        # ##############
+        time.sleep(0.1)
+        # ##############
+        # /HACK
+        # ##############
+
+        log.debug("ExchangeManager.stopping (%d connections)", len(self._nodes))
+
+        for name in self._nodes:
+            self._nodes[name].client.close()
+            self._ioloops[name].kill()
+            self._nodes[name].client.ioloop.start()     # loop until connection closes
+
+    @property
+    def default_node(self):
+        """
+        Returns the default node connection.
+        """
+        if self.NODE_PREFIX in self._nodes:
+            return self._nodes[self.NODE_PREFIX]
+        elif len(self._nodes):
+            return self._nodes.values()[0]
+
+        return None
 
     @property
     def xn_by_xs(self):
@@ -91,20 +185,6 @@ class ExchangeManager(object):
 
         self._xs_cache[name] = xs_objs[0]
         return xs_objs[0]
-
-    def start(self):
-        log.debug("ExchangeManager starting ...")
-
-        # Establish connection to broker
-        # @TODO: raise error if sux
-        node, ioloop = messaging.make_node()
-
-        self._transport = AMQPTransport.get_instance()
-        self._client    = self._get_channel(node)
-
-        # Declare root exchange
-        #self.default_xs.ensure_exists(self._get_channel())
-        return node, ioloop
 
     def _ems_available(self):
         """
@@ -264,9 +344,6 @@ class ExchangeManager(object):
             self._ems_client.undeclare_exchange_name(xno_id)        # "canonical name" currently understood to be RR id
         else:
             xn.delete()
-
-    def stop(self, *args, **kwargs):
-        log.debug("ExchangeManager stopping ...")
 
     # transport implementations - XOTransport objects call here
     def declare_exchange(self, exchange, exchange_type='topic', durable=False, auto_delete=True):

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -16,6 +16,11 @@ from pyon.net.transport import BaseTransport, TransportError, AMQPTransport
 from pyon.core.bootstrap import get_sys_name
 from pyon.net.channel import RecvChannel
 from pyon.util.config import CFG
+from pyon.util.containers import DotDict
+
+def _make_server_cfg(**kwargs):
+    ddkwargs = DotDict(**kwargs)
+    return DotDict(CFG.container, messaging=DotDict(CFG.container.messaging, server=ddkwargs))
 
 @attr('UNIT', group='COI')
 @patch('pyon.ion.exchange.messaging')
@@ -28,48 +33,46 @@ class TestExchangeManager(PyonTestCase):
     def test_verify_service(self, mockmessaging):
         PyonTestCase.test_verify_service(self)
 
-    @patch.dict('pyon.ion.exchange.CFG', server={})
+    @patch.dict('pyon.ion.exchange.CFG', container=_make_server_cfg())
     def test_start_with_no_connections(self, mockmessaging):
         self.assertRaises(ExchangeManagerError, self.ex_manager.start)
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp}, container=_make_server_cfg(primary='amqp'))
     def test_start_with_one_connection(self, mockmessaging):
         mockmessaging.make_node.return_value = (Mock(), Mock())     # node, ioloop
         self.ex_manager.start()
 
-        mockmessaging.make_node.assert_called_once_with(sentinel.amqp, 'amqp', 0)
-        self.assertIn('amqp', self.ex_manager._nodes)
-        self.assertIn('amqp', self.ex_manager._ioloops)
-        self.assertEquals(self.ex_manager._nodes['amqp'], mockmessaging.make_node.return_value[0])
-        self.assertEquals(self.ex_manager._ioloops['amqp'], mockmessaging.make_node.return_value[1])
+        mockmessaging.make_node.assert_called_once_with(sentinel.amqp, 'primary', 0)
+        self.assertIn('primary', self.ex_manager._nodes)
+        self.assertIn('primary', self.ex_manager._ioloops)
+        self.assertEquals(self.ex_manager._nodes['primary'], mockmessaging.make_node.return_value[0])
+        self.assertEquals(self.ex_manager._ioloops['primary'], mockmessaging.make_node.return_value[1])
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_again':sentinel.amqp_again})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_again':sentinel.amqp_again}, container=_make_server_cfg(primary='amqp', secondary='amqp_again'))
     def test_start_with_multi_connections(self, mockmessaging):
         mockmessaging.make_node.return_value = (Mock(), Mock())     # node, ioloop
         self.ex_manager.start()
 
-        mockmessaging.make_node.assert_calls(call(sentinel.amqp, 'amqp', 0), call(sentinel.amqp_again, 'amqp_again', 0))
+        mockmessaging.make_node.assert_calls(call(sentinel.amqp, 'primary', 0), call(sentinel.amqp_again, 'secondary', 0))
 
-        self.assertIn('amqp', self.ex_manager._nodes)
-        self.assertIn('amqp', self.ex_manager._ioloops)
-        self.assertEquals(self.ex_manager._nodes['amqp'], mockmessaging.make_node.return_value[0])
-        self.assertEquals(self.ex_manager._ioloops['amqp'], mockmessaging.make_node.return_value[1])
+        self.assertIn('primary', self.ex_manager._nodes)
+        self.assertIn('primary', self.ex_manager._ioloops)
+        self.assertEquals(self.ex_manager._nodes['primary'], mockmessaging.make_node.return_value[0])
+        self.assertEquals(self.ex_manager._ioloops['primary'], mockmessaging.make_node.return_value[1])
 
-        self.assertIn('amqp_again', self.ex_manager._nodes)
-        self.assertIn('amqp_again', self.ex_manager._ioloops)
-        self.assertEquals(self.ex_manager._nodes['amqp_again'], mockmessaging.make_node.return_value[0])
-        self.assertEquals(self.ex_manager._ioloops['amqp_again'], mockmessaging.make_node.return_value[1])
+        self.assertIn('secondary', self.ex_manager._nodes)
+        self.assertIn('secondary', self.ex_manager._ioloops)
+        self.assertEquals(self.ex_manager._nodes['secondary'], mockmessaging.make_node.return_value[0])
+        self.assertEquals(self.ex_manager._ioloops['secondary'], mockmessaging.make_node.return_value[1])
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'not_amqp':sentinel.not_amqp})
-    def test_start_with_non_prefixed_connections(self, mockmessaging):
+    @patch.dict('pyon.ion.exchange.CFG', server={}, container=_make_server_cfg(primary='idontexist'))
+    def test_start_with_non_existing_connection_in_server(self, mockmessaging):
         mockmessaging.make_node.return_value = (Mock(), Mock())     # node, ioloop
-        self.ex_manager.start()
 
-        mockmessaging.make_node.assert_called_once_with(sentinel.amqp, 'amqp', 0)
+        self.assertRaises(ExchangeManagerError, self.ex_manager.start)
+        self.assertFalse(mockmessaging.make_node.called)
 
-        self.assertEqual(len(self.ex_manager._nodes), 1)
-
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_fail':sentinel.amqp_fail})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_fail':sentinel.amqp_fail}, container=_make_server_cfg(primary='amqp', secondary='amqp_fail'))
     def test_start_with_working_and_failing_connection(self, mockmessaging):
 
         # set up return values - first is amqp (Working) second is amqp_fail (not working)
@@ -77,7 +80,7 @@ class TestExchangeManager(PyonTestCase):
         nodemock.running = False
         iomock = Mock()
         def ret_vals(conf, name, timeout):
-            if 'fail' in name:
+            if name == 'secondary':
                 return (nodemock, iomock)
             return (Mock(), Mock())
 
@@ -88,7 +91,7 @@ class TestExchangeManager(PyonTestCase):
         self.assertEquals(len(self.ex_manager._nodes), 1)
         iomock.kill.assert_called_once_with()
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp_fail':sentinel.amqp_fail})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp_fail':sentinel.amqp_fail}, container=_make_server_cfg(primary='amqp_fail'))
     def test_start_with_only_failing_connections(self, mockmessaging):
         nodemock = Mock()
         nodemock.running = False
@@ -99,7 +102,7 @@ class TestExchangeManager(PyonTestCase):
         self.assertRaises(ExchangeManagerError, self.ex_manager.start)
         iomock.kill.assert_called_once_with()
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp}, container=_make_server_cfg(primary='amqp'))
     def test_start_stop(self, mockmessaging):
         nodemock = Mock()
         iomock = Mock()
@@ -114,7 +117,7 @@ class TestExchangeManager(PyonTestCase):
     def test_default_node_no_connections(self, mockmessaging):
         self.assertIsNone(self.ex_manager.default_node)
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp_not_default':sentinel.amqp_not_default})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp_not_default':sentinel.amqp_not_default}, container=_make_server_cfg(secondary='amqp_not_default'))
     def test_default_node_no_default_name(self, mockmessaging):
         nodemock = Mock()
         mockmessaging.make_node.return_value = (nodemock, Mock())     # node, ioloop
@@ -123,14 +126,14 @@ class TestExchangeManager(PyonTestCase):
 
         self.assertEquals(self.ex_manager.default_node, nodemock)
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_again':sentinel.amqp_again})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_again':sentinel.amqp_again}, container=_make_server_cfg(primary='amqp', secondary='amqp_again'))
     def test_default_node(self, mockmessaging):
 
         # set up return values - amqp returns this named version, amqp_again does not
         nodemock = Mock()
         iomock = Mock()
         def ret_vals(conf, name, timeout):
-            if name == 'amqp':
+            if name == 'primary':
                 return (nodemock, iomock)
             return (Mock(), Mock())
 
@@ -155,22 +158,22 @@ class TestExchangeManagerInt(IonIntegrationTestCase):
     def setUp(self):
         pass
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':CFG.server.amqp, 'couchdb':CFG.server.couchdb})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':CFG.server.amqp, 'couchdb':CFG.server.couchdb}, container=_make_server_cfg(primary='amqp'))
     def test_start_stop(self):
         self._start_container()
 
         self.assertEquals(self.container.node, self.container.ex_manager.default_node)
         self.assertEquals(len(self.container.ex_manager._nodes), 1)
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':CFG.server.amqp, 'couchdb':CFG.server.couchdb, 'amqp_fail':fail_cfg})
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':CFG.server.amqp, 'couchdb':CFG.server.couchdb, 'amqp_fail':fail_cfg}, container=_make_server_cfg(primary='amqp', secondary='amqp_fail'))
     def test_start_stop_with_one_success_and_one_failure(self):
         self._start_container()
 
         self.assertEquals(len(self.container.ex_manager._nodes), 1)
-        self.assertIn('amqp', self.container.ex_manager._nodes)
-        self.assertNotIn('amqp_fail', self.container.ex_manager._nodes)
+        self.assertIn('primary', self.container.ex_manager._nodes)
+        self.assertNotIn('secondary', self.container.ex_manager._nodes)
 
-    @patch.dict('pyon.ion.exchange.CFG', server={'couchdb':CFG.server.couchdb, 'amqp':fail_cfg})
+    @patch.dict('pyon.ion.exchange.CFG', server={'couchdb':CFG.server.couchdb, 'amqp':fail_cfg}, container=_make_server_cfg())
     def test_start_stop_with_no_connections(self):
         self.assertRaises(ExchangeManagerError, self._start_container)
 

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -111,7 +111,7 @@ class TestExchangeManager(PyonTestCase):
         self.ex_manager.start()
         self.ex_manager.stop()
 
-        nodemock.client.close.assert_called_once_with()
+        nodemock.stop_node.assert_called_once_with()
         iomock.kill.assert_called_once_with()
 
     def test_default_node_no_connections(self, mockmessaging):

--- a/pyon/ion/test/test_exchange.py
+++ b/pyon/ion/test/test_exchange.py
@@ -3,23 +3,180 @@
 __author__ = 'Dave Foster <dfoster@asascience.com>'
 
 from pyon.util.int_test import IonIntegrationTestCase
-from pyon.util.unit_test import IonUnitTestCase
+from pyon.util.unit_test import PyonTestCase
 from nose.plugins.attrib import attr
 from examples.service.hello_service import HelloService
 from interface.services.examples.hello.ihello_service import HelloServiceClient
 from pyon.net.endpoint import RPCServer
 from pyon.util.async import spawn
 import unittest
-from pyon.ion.exchange import ExchangeManager, ION_ROOT_XS, ExchangeNameProcess, ExchangeSpace, ExchangePoint, ExchangeNameService, ExchangeName, ExchangeNameQueue
-from mock import Mock, sentinel, patch
+from pyon.ion.exchange import ExchangeManager, ION_ROOT_XS, ExchangeNameProcess, ExchangeSpace, ExchangePoint, ExchangeNameService, ExchangeName, ExchangeNameQueue, ExchangeManagerError
+from mock import Mock, sentinel, patch, call
 from pyon.net.transport import BaseTransport, TransportError, AMQPTransport
 from pyon.core.bootstrap import get_sys_name
 from pyon.net.channel import RecvChannel
 from pyon.util.config import CFG
 
+@attr('UNIT', group='COI')
+@patch('pyon.ion.exchange.messaging')
+class TestExchangeManager(PyonTestCase):
+    def setUp(self):
+        self.container = Mock()
+        self.ex_manager = ExchangeManager(self.container)
+        self.ex_manager._get_channel = Mock()
+
+    def test_verify_service(self, mockmessaging):
+        PyonTestCase.test_verify_service(self)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={})
+    def test_start_with_no_connections(self, mockmessaging):
+        self.assertRaises(ExchangeManagerError, self.ex_manager.start)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp})
+    def test_start_with_one_connection(self, mockmessaging):
+        mockmessaging.make_node.return_value = (Mock(), Mock())     # node, ioloop
+        self.ex_manager.start()
+
+        mockmessaging.make_node.assert_called_once_with(sentinel.amqp, 'amqp', 0)
+        self.assertIn('amqp', self.ex_manager._nodes)
+        self.assertIn('amqp', self.ex_manager._ioloops)
+        self.assertEquals(self.ex_manager._nodes['amqp'], mockmessaging.make_node.return_value[0])
+        self.assertEquals(self.ex_manager._ioloops['amqp'], mockmessaging.make_node.return_value[1])
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_again':sentinel.amqp_again})
+    def test_start_with_multi_connections(self, mockmessaging):
+        mockmessaging.make_node.return_value = (Mock(), Mock())     # node, ioloop
+        self.ex_manager.start()
+
+        mockmessaging.make_node.assert_calls(call(sentinel.amqp, 'amqp', 0), call(sentinel.amqp_again, 'amqp_again', 0))
+
+        self.assertIn('amqp', self.ex_manager._nodes)
+        self.assertIn('amqp', self.ex_manager._ioloops)
+        self.assertEquals(self.ex_manager._nodes['amqp'], mockmessaging.make_node.return_value[0])
+        self.assertEquals(self.ex_manager._ioloops['amqp'], mockmessaging.make_node.return_value[1])
+
+        self.assertIn('amqp_again', self.ex_manager._nodes)
+        self.assertIn('amqp_again', self.ex_manager._ioloops)
+        self.assertEquals(self.ex_manager._nodes['amqp_again'], mockmessaging.make_node.return_value[0])
+        self.assertEquals(self.ex_manager._ioloops['amqp_again'], mockmessaging.make_node.return_value[1])
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'not_amqp':sentinel.not_amqp})
+    def test_start_with_non_prefixed_connections(self, mockmessaging):
+        mockmessaging.make_node.return_value = (Mock(), Mock())     # node, ioloop
+        self.ex_manager.start()
+
+        mockmessaging.make_node.assert_called_once_with(sentinel.amqp, 'amqp', 0)
+
+        self.assertEqual(len(self.ex_manager._nodes), 1)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_fail':sentinel.amqp_fail})
+    def test_start_with_working_and_failing_connection(self, mockmessaging):
+
+        # set up return values - first is amqp (Working) second is amqp_fail (not working)
+        nodemock = Mock()
+        nodemock.running = False
+        iomock = Mock()
+        def ret_vals(conf, name, timeout):
+            if 'fail' in name:
+                return (nodemock, iomock)
+            return (Mock(), Mock())
+
+        mockmessaging.make_node.side_effect = ret_vals
+
+        self.ex_manager.start()
+
+        self.assertEquals(len(self.ex_manager._nodes), 1)
+        iomock.kill.assert_called_once_with()
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp_fail':sentinel.amqp_fail})
+    def test_start_with_only_failing_connections(self, mockmessaging):
+        nodemock = Mock()
+        nodemock.running = False
+        iomock = Mock()
+
+        mockmessaging.make_node.return_value = (nodemock, iomock)
+
+        self.assertRaises(ExchangeManagerError, self.ex_manager.start)
+        iomock.kill.assert_called_once_with()
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp})
+    def test_start_stop(self, mockmessaging):
+        nodemock = Mock()
+        iomock = Mock()
+        mockmessaging.make_node.return_value = (nodemock, iomock)
+
+        self.ex_manager.start()
+        self.ex_manager.stop()
+
+        nodemock.client.close.assert_called_once_with()
+        iomock.kill.assert_called_once_with()
+
+    def test_default_node_no_connections(self, mockmessaging):
+        self.assertIsNone(self.ex_manager.default_node)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp_not_default':sentinel.amqp_not_default})
+    def test_default_node_no_default_name(self, mockmessaging):
+        nodemock = Mock()
+        mockmessaging.make_node.return_value = (nodemock, Mock())     # node, ioloop
+
+        self.ex_manager.start()
+
+        self.assertEquals(self.ex_manager.default_node, nodemock)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':sentinel.amqp, 'amqp_again':sentinel.amqp_again})
+    def test_default_node(self, mockmessaging):
+
+        # set up return values - amqp returns this named version, amqp_again does not
+        nodemock = Mock()
+        iomock = Mock()
+        def ret_vals(conf, name, timeout):
+            if name == 'amqp':
+                return (nodemock, iomock)
+            return (Mock(), Mock())
+
+        mockmessaging.make_node.side_effect = ret_vals
+        self.ex_manager.start()
+
+        self.assertEquals(self.ex_manager.default_node, nodemock)
+
+@attr('INT', group='COI')
+class TestExchangeManagerInt(IonIntegrationTestCase):
+
+    fail_cfg = {
+        'type':'amqp91',
+        'host':CFG.server.amqp.host,
+        'port':CFG.server.amqp.port,
+        'username':'THIS_SHOULD_NOT_EXIST',
+        'password':'REALLY_DOESNT_MATTER',
+        'vhost': '/',
+        'heartbeat':30,
+    }
+
+    def setUp(self):
+        pass
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':CFG.server.amqp, 'couchdb':CFG.server.couchdb})
+    def test_start_stop(self):
+        self._start_container()
+
+        self.assertEquals(self.container.node, self.container.ex_manager.default_node)
+        self.assertEquals(len(self.container.ex_manager._nodes), 1)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'amqp':CFG.server.amqp, 'couchdb':CFG.server.couchdb, 'amqp_fail':fail_cfg})
+    def test_start_stop_with_one_success_and_one_failure(self):
+        self._start_container()
+
+        self.assertEquals(len(self.container.ex_manager._nodes), 1)
+        self.assertIn('amqp', self.container.ex_manager._nodes)
+        self.assertNotIn('amqp_fail', self.container.ex_manager._nodes)
+
+    @patch.dict('pyon.ion.exchange.CFG', server={'couchdb':CFG.server.couchdb, 'amqp':fail_cfg})
+    def test_start_stop_with_no_connections(self):
+        self.assertRaises(ExchangeManagerError, self._start_container)
+
 @attr('UNIT', group='exchange')
-@patch.dict(CFG, {'container':{'exchange':{'auto_register': False}}})
-class TestExchangeObjects(IonUnitTestCase):
+@patch.dict('pyon.ion.exchange.CFG', {'container':{'exchange':{'auto_register': False}}})
+class TestExchangeObjects(PyonTestCase):
     def setUp(self):
         self.ex_manager = ExchangeManager(Mock())
         self.ex_manager._transport  = Mock(BaseTransport)
@@ -255,7 +412,7 @@ class TestExchangeObjects(IonUnitTestCase):
 
 
 @attr('INT', group='exchange')
-@patch.dict(CFG, {'container':{'exchange':{'auto_register': False}}})
+@patch.dict('pyon.ion.exchange.CFG', {'container':{'exchange':{'auto_register': False}}})
 class TestExchangeObjectsInt(IonIntegrationTestCase):
     def setUp(self):
         self._start_container()
@@ -285,7 +442,7 @@ class TestExchangeObjectsInt(IonIntegrationTestCase):
         raise unittest.SkipTest("not done yet")
 
 @attr('INT', group='exchange')
-@patch.dict(CFG, {'container':{'exchange':{'auto_register': False}}})
+@patch.dict('pyon.ion.exchange.CFG', {'container':{'exchange':{'auto_register': False}}})
 class TestExchangeObjectsCreateDelete(IonIntegrationTestCase):
     """
     Tests creation and deletion of things on the broker.

--- a/pyon/net/messaging.py
+++ b/pyon/net/messaging.py
@@ -47,6 +47,25 @@ class NodeB(amqp.Node):
         self.running = True
         self.ready.set()
 
+    def stop_node(self):
+        """
+        Closes the connection to the broker, cleans up resources held by this node.
+        """
+        log.debug("NodeB.stop_node (running: %s)", self.running)
+
+        if self.running:
+            # clean up pooling before we shut connection
+            self._destroy_pool()
+            self.client.close()
+        self.running = False
+
+    def _destroy_pool(self):
+        """
+        Explicitly deletes pooled queues in this Node.
+        """
+        for chan in self._bidir_pool.itervalues():
+            chan._destroy_queue()
+
     def _new_channel(self, ch_type, ch_number=None, **kwargs):
         """
         Creates a pyon Channel based on the passed in type, and activates it for use.

--- a/pyon/net/test/test_channel.py
+++ b/pyon/net/test/test_channel.py
@@ -789,11 +789,34 @@ class TestListenChannel(PyonTestCase):
         self.assertEquals(ac.close.call_count, 0)
 
 @attr('UNIT')
-class TestSusbcriberChannel(PyonTestCase):
-    """
-    SubscriberChannel is a blank for now
-    """
-    pass
+class TestSubscriberChannel(PyonTestCase):
+
+    def test_close_does_delete_if_anonymous_and_not_auto_delete(self):
+        ch = SubscriberChannel()
+        ch._queue_auto_delete = False
+        ch._destroy_queue = Mock()
+        ch._recv_name = NameTrio(sentinel.exchange, 'amq.gen-ABCD')
+
+        ch.close_impl()
+        ch._destroy_queue.assert_called_once_with()
+
+    def test_close_does_not_delete_if_named(self):
+        ch = SubscriberChannel()
+        ch._queue_auto_delete = False
+        ch._destroy_queue = Mock()
+        ch._recv_name = NameTrio(sentinel.exchange, 'some-named-queue')
+
+        ch.close_impl()
+        self.assertFalse(ch._destroy_queue.called)
+
+    def test_close_does_not_delete_if_anon_but_auto_delete(self):
+        ch = SubscriberChannel()
+        ch._queue_auto_delete = True
+        ch._destroy_queue = Mock()
+        ch._recv_name = NameTrio(sentinel.exchange, 'amq.gen-ABCD')
+
+        ch.close_impl()
+        self.assertFalse(ch._destroy_queue.called)
 
 @attr('UNIT')
 class TestServerChannel(PyonTestCase):

--- a/pyon/net/test/test_messaging.py
+++ b/pyon/net/test/test_messaging.py
@@ -4,7 +4,7 @@ __author__ = 'Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
 
 from pyon.net.messaging import NodeB, ioloop, make_node, PyonSelectConnection
-from pyon.net.channel import BaseChannel, BidirClientChannel
+from pyon.net.channel import BaseChannel, BidirClientChannel, RecvChannel
 from pyon.util.unit_test import PyonTestCase
 from mock import Mock, sentinel, patch
 from nose.plugins.attrib import attr
@@ -190,6 +190,37 @@ class TestNodeB(PyonTestCase):
 
         # we got the first mocked channel back
         self.assertEquals(ch3.get_channel_id(), sentinel.chid)
+
+    def test_stop_node(self):
+        self._node.client = Mock()
+        self._node._destroy_pool = Mock()
+        self._node.running = True
+
+        self._node.stop_node()
+
+        self._node.client.close.assert_called_once_with()
+        self._node._destroy_pool.assert_called_once_with()
+        self.assertFalse(self._node.running)
+
+    def test_stop_node_not_running(self):
+        self._node.client = Mock()
+        self._node._destroy_pool = Mock()
+        self._node.running = False
+
+        self._node.stop_node()
+
+        self.assertFalse(self._node.client.close.called)
+        self.assertFalse(self._node._destroy_pool.called)
+        self.assertFalse(self._node.running)
+
+    def test_destroy_pool(self):
+        chmock = Mock(spec=RecvChannel)
+        for x in xrange(20):
+            self._node._bidir_pool[x] = chmock
+
+        self._node._destroy_pool()
+
+        self.assertEqual(chmock._destroy_queue.call_count, 20)
 
 @attr('UNIT')
 class TestMessaging(PyonTestCase):

--- a/pyon/net/test/test_messaging.py
+++ b/pyon/net/test/test_messaging.py
@@ -223,10 +223,10 @@ class TestMessaging(PyonTestCase):
             return sentinel.connection
 
         with patch('pyon.net.messaging.PyonSelectConnection', new=select_connection):
-            node, ilp = make_node(connection_params)
+            node, ilp = make_node(connection_params, name=sentinel.name)
 
         self.assertEquals(ilp, sentinel.ioloop_process)
-        gevmock.assert_called_once_with(ioloop, sentinel.connection)
+        gevmock.assert_called_once_with(ioloop, sentinel.connection, name=sentinel.name)
 
 @attr('UNIT')
 class TestPyonSelectConnection(PyonTestCase):


### PR DESCRIPTION
Connections to brokers are defined in `res/config/pyon.yml`, in two sections, `container.messaging.server` to get names like `primary` and `priviledged` [sic], and they key into connection information in `server`.

These changes move the concept of managing multiple nodes into the `ExchangeManager` class which every Container has.  Instead of `ExchangeManager.start` returning the default node and ioloop greenlet to be saved by the Container, it is now saved by the EM and indexable.
- If some connections fail but at least one succeeds, just warns about it.  If all fail or none are defined, throws an Exception
- `Container.node` is now a property that passes through to `ExchangeManager.default_node`, also a property, which returns `primary`, failing that any available, failing that a None.  Endpoints automatically get the `primary` still via this scheme.
- Exchange objects will use the `priviledged` [sic] connection if available.  (TODO: make sure EMS service uses it as well, it should)
- Full set of tests (unit/int)

TBR @mmeisinger, please don't merge until we've reviewed either offline or Monday.
