### PR TITLE
Luke: fixes get_safe

### DIFF
--- a/pyon/util/containers.py
+++ b/pyon/util/containers.py
@@ -88,7 +88,10 @@ class DotDict(DotNotationGetItem, dict):
         @brief Returns value of qualified key, such as "system.name" or None if not exists.
                 If default is given, returns the default. No exception thrown.
         """
-        return get_safe(self, qual_key) or default
+        value = get_safe(self, qual_key)
+        if value is None:
+            value = default
+        return value
 
     @classmethod
     def fromkeys(cls, seq, value=None):


### PR DESCRIPTION
- get_safe used an `or` to evaluate the existence of a value which fails
  for boolean false statements (`[]`, `0`, `{}` etc which do exist).
- Changed the evaluation to evaluate existence based on `None`

To reproduce the error

```
from pyon.util.containers import DotDict
a = DotDict()
a['test'] = 0
a.get('test',1)
> 1 # this is bad, it should be 0
```
