### PR TITLE
CouchDB bulk association determination

### DIFF
--- a/pyon/datastore/couchdb/couchdb_config.py
+++ b/pyon/datastore/couchdb/couchdb_config.py
@@ -78,6 +78,14 @@ function(doc) {
     emit([doc.p, doc.s, doc.o, doc.at, doc.srv, doc.orv], doc);
   }
 }""",
+        },
+        'by_bulk':{
+            'map':"""
+function(doc) {
+  if(doc.type_ == "Association") {
+    emit(doc.s, doc.o);
+  }
+}""",
         }
     },
 

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from pyon.util.arg_check import validate_is_instance
 
 __author__ = 'Thomas R. Lennan, Michael Meisinger'
 __license__ = 'Apache 2.0'
@@ -18,6 +17,7 @@ from pyon.datastore.datastore import DataStore
 from pyon.datastore.couchdb.couchdb_config import get_couchdb_views
 from pyon.ion.resource import CommonResourceLifeCycleSM
 from pyon.util.log import log
+from pyon.util.arg_check import validate_is_instance
 from pyon.core.bootstrap import CFG
 
 # Token for a most likely non-inclusive key range upper bound (end_key), for queries such as

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -412,15 +412,14 @@ class CouchDB_DataStore(DataStore):
     def find_associations_mult(self, subjects, id_only=False):
         ds, datastore_name = self._get_datastore()
         validate_is_instance(subjects, list, 'subjects is not a list of resource_ids')
-        view_args = dict(keys=subjects)
-        if not id_only:
-            view_args['include_docs'] = True
+        view_args = dict(keys=subjects, include_docs=True)
         results = self.query_view(self._get_viewname("association","by_bulk"), view_args)
         ids = list([i['value'] for i in results])
+        assocs = list([i['doc'] for i in results])
         if id_only:
-            return ids
+            return ids, assocs
         else:
-            return self.read_mult(ids)
+            return self.read_mult(ids), assocs
 
 
 

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pyon.util.arg_check import validate_is_instance
 
 __author__ = 'Thomas R. Lennan, Michael Meisinger'
 __license__ = 'Apache 2.0'
@@ -407,6 +408,22 @@ class CouchDB_DataStore(DataStore):
             return True
 
         return False
+
+    def find_associations_mult(self, subjects, id_only=False):
+        ds, datastore_name = self._get_datastore()
+        validate_is_instance(subjects, list, 'subjects is not a list of resource_ids')
+        view_args = dict(keys=subjects)
+        if not id_only:
+            view_args['include_docs'] = True
+        results = self.query_view(self._get_viewname("association","by_bulk"), view_args)
+        ids = list([i['value'] for i in results])
+        if id_only:
+            return ids
+        else:
+            return self.read_mult(ids)
+
+
+
 
     def find_objects(self, subject, predicate=None, object_type=None, id_only=False, **kwargs):
         log.debug("find_objects(subject=%s, predicate=%s, object_type=%s, id_only=%s" % (subject, predicate, object_type, id_only))

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -145,8 +145,9 @@ class ResourceRegistry(object):
         owners,assocs = self.rr_store.find_objects(object_id, PRED.hasOwner, RT.ActorIdentity, id_only=True)
         for aid in assocs:
             self.rr_store.delete_association(aid)
-
-        res = self.rr_store.delete(res_obj)
+        res_obj.lcstate = 'RETIRED'
+        self.rr_store.update(res_obj)
+        res = self.rr_store.delete(object_id)
 
         self.event_pub.publish_event(event_type="ResourceModifiedEvent",
                                      origin=res_obj._id, origin_type=res_obj._get_type(),

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -308,6 +308,9 @@ class ResourceRegistry(object):
     def find_associations(self, subject="", predicate="", object="", assoc_type=None, id_only=False):
         return self.rr_store.find_associations(subject, predicate, object, assoc_type, id_only=id_only)
 
+    def find_associations_mult(self, subjects=[], id_only=False):
+        return self.rr_store.find_associations_mult(subjects=subjects, id_only=id_only)
+
     def get_association(self, subject="", predicate="", object="", assoc_type=None, id_only=False):
         if predicate:
             assoc_type = assoc_type or AT.H2H


### PR DESCRIPTION
Primarily intended to speed up and improve overall performance for association traversal in discovery.

`find_associations_mult` provides the capability to determine all the associations and objects belonging to a list of resources in a single query to CouchDB

```
><> org_id = '76f054f625804ee9a7198c2404c798fa'

><> org_manager = 'be31988aca3e495cbc9297741e2250d1'

><> pn.resource_registry.find_associations_mult([org_id])
--> 
[<interface.objects.UserRole at 0x103ca7810>,
 <interface.objects.ActorIdentity at 0x103ca7f90>,
 <interface.objects.ExchangeSpace at 0x103ca7b50>,
 <interface.objects.UserRole at 0x103ca7590>,
 <interface.objects.UserRole at 0x103ca7f10>]

><> pn.resource_registry.find_as
pn.resource_registry.find_associations       pn.resource_registry.find_associations_mult  

><> pn.resource_registry.find_associations_mult([org_id, org_manager])
--> 
[<interface.objects.UserRole at 0x103d270d0>,
 <interface.objects.ActorIdentity at 0x103d279d0>,
 <interface.objects.ExchangeSpace at 0x103ca7550>,
 <interface.objects.UserRole at 0x103d1de90>,
 <interface.objects.UserRole at 0x103d1d090>,
 <interface.objects.ActorIdentity at 0x103d1d1d0>]

```
