### PR TITLE
Interceptor Redo

### DIFF
--- a/pyon/core/bootstrap.py
+++ b/pyon/core/bootstrap.py
@@ -101,10 +101,6 @@ def bootstrap_pyon():
     from pyon.ion import resource
     resource.load_definitions()
 
-    # Load interceptors
-    from pyon.net.endpoint import instantiate_interceptors
-    instantiate_interceptors(CFG.interceptor)
-
     # Services
     service_registry.load_service_mods('interface/services')
     service_registry.build_service_map()

--- a/pyon/core/governance/governance_interceptor.py
+++ b/pyon/core/governance/governance_interceptor.py
@@ -13,7 +13,16 @@ from pyon.util.log import log
 class BaseInternalGovernanceInterceptor(Interceptor):
 
     def __init__(self, *args, **kwargs):
-        self.governance_controller = Container.instance.governance_controller
+        pass
+
+    @property
+    def governance_controller(self):
+        """
+        Property to get governance controller from Container, if the container exists.
+        """
+        if Container.instance is not None:
+            return Container.instance.governance_controller
+        return None
 
     def outgoing(self, invocation):
         pass
@@ -22,7 +31,7 @@ class BaseInternalGovernanceInterceptor(Interceptor):
         pass
 
 
-class GovernanceInterceptor(Interceptor):
+class GovernanceInterceptor(BaseInternalGovernanceInterceptor):
 
 
     def configure(self, config):
@@ -42,8 +51,8 @@ class GovernanceInterceptor(Interceptor):
         else:
             log.debug("GovernanceInterceptor.outgoing: %s", invocation)
 
-        if Container.instance.governance_controller is not None:
-            Container.instance.governance_controller.process_outgoing_message(invocation)
+        if self.governance_controller is not None:
+            self.governance_controller.process_outgoing_message(invocation)
 
         return invocation
 
@@ -57,8 +66,8 @@ class GovernanceInterceptor(Interceptor):
         else:
             log.debug("GovernanceInterceptor.incoming: %s", invocation)
 
-        if Container.instance.governance_controller is not None:
-            Container.instance.governance_controller.process_incoming_message(invocation)
+        if self.governance_controller is not None:
+            self.governance_controller.process_incoming_message(invocation)
 
         return invocation
 

--- a/pyon/ion/endpoint.py
+++ b/pyon/ion/endpoint.py
@@ -6,7 +6,7 @@ from pyon.util import log
 __author__ = 'Michael Meisinger, David Stuebe, Dave Foster <dfoster@asascience.com>'
 __license__ = 'Apache 2.0'
 
-from pyon.net.endpoint import Publisher, Subscriber, EndpointUnit, process_interceptors, interceptors, RPCRequestEndpointUnit, BaseEndpoint, RPCClient, RPCResponseEndpointUnit, RPCServer
+from pyon.net.endpoint import Publisher, Subscriber, EndpointUnit, process_interceptors, RPCRequestEndpointUnit, BaseEndpoint, RPCClient, RPCResponseEndpointUnit, RPCServer
 from pyon.util.log import log
 
 
@@ -38,7 +38,7 @@ class ProcessEndpointUnitMixin(EndpointUnit):
         This is a request, so the order should be Message, Process
         """
         inv_one = EndpointUnit._intercept_msg_in(self, inv)
-        inv_two = process_interceptors(interceptors["process_incoming"] if "process_incoming" in interceptors else [], inv_one)
+        inv_two = process_interceptors(self.interceptors["process_incoming"] if "process_incoming" in self.interceptors else [], inv_one)
         return inv_two
 
     def _intercept_msg_out(self, inv):
@@ -47,7 +47,7 @@ class ProcessEndpointUnitMixin(EndpointUnit):
 
         This is request, so the order should be Process, Message
         """
-        inv_one = process_interceptors(interceptors["process_outgoing"] if "process_outgoing" in interceptors else [], inv)
+        inv_one = process_interceptors(self.interceptors["process_outgoing"] if "process_outgoing" in self.interceptors else [], inv)
         inv_two = EndpointUnit._intercept_msg_out(self, inv_one)
 
         return inv_two

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -126,6 +126,9 @@ class ExchangeManager(object):
         self._transport = AMQPTransport.get_instance()
         self._client    = self._get_channel(self._nodes.get('priviledged', self._nodes.values()[0]))        # @TODO
 
+        # load interceptors into each
+        map(lambda x: x.setup_interceptors(CFG.interceptor), self._nodes.itervalues())
+
         log.debug("Started %d connections (%s)", len(self._nodes), ",".join(self._nodes.iterkeys()))
 
         # Declare root exchange

--- a/pyon/ion/test/test_endpoint.py
+++ b/pyon/ion/test/test_endpoint.py
@@ -16,7 +16,6 @@ sentinel_interceptors = {'message_incoming': sentinel.msg_incoming,
                          'process_outgoing': sentinel.proc_outgoing}
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, sentinel_interceptors, clear=True)
 class TestProcessEndpointUnitMixin(PyonTestCase):
 
     @patch('pyon.net.endpoint.EndpointUnit.__init__')
@@ -37,7 +36,7 @@ class TestProcessEndpointUnitMixin(PyonTestCase):
     def test__intercept_msg_in(self, mocknpi, mockipi):
         mockipi.return_value = sentinel.inv2
         mocknpi.return_value = sentinel.inv2
-        ep = ProcessEndpointUnitMixin(process=sentinel.proc)
+        ep = ProcessEndpointUnitMixin(process=sentinel.proc, interceptors=sentinel_interceptors)
 
         ep._intercept_msg_in(sentinel.inv)
 
@@ -49,7 +48,7 @@ class TestProcessEndpointUnitMixin(PyonTestCase):
     def test__intercept_msg_out(self, mocknpi, mockipi):
         mockipi.return_value = sentinel.inv2
         mocknpi.return_value = sentinel.inv2
-        ep = ProcessEndpointUnitMixin(process=sentinel.proc)
+        ep = ProcessEndpointUnitMixin(process=sentinel.proc, interceptors=sentinel_interceptors)
 
         ep._intercept_msg_out(sentinel.inv)
 
@@ -191,7 +190,7 @@ class TestProcessRPCResponseEndpointUnit(PyonTestCase):
         procmock = Mock()
         procmock.push_context = MagicMock()
 
-        ep = ProcessRPCResponseEndpointUnit(process=procmock)
+        ep = ProcessRPCResponseEndpointUnit(process=procmock, interceptors={})
         ep._message_received(sentinel.msg, sentinel.headers)
 
         procmock.push_context.assert_called_once_with(sentinel.headers)

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -23,39 +23,6 @@ import traceback
 import sys
 from pyon.util.sflow import SFlowManager
 
-
-interceptors = {"message_incoming": [], "message_outgoing": [], "process_incoming": [], "process_outgoing": []}
-
-# Note: This is now called from pyon.core.bootstrap
-def instantiate_interceptors(interceptor_cfg):
-    stack = interceptor_cfg["stack"]
-    defs = interceptor_cfg["interceptors"]
-
-    by_name_dict = {}
-    for type_and_direction in stack:
-        interceptor_names = stack[type_and_direction]
-        for name in interceptor_names:
-            if name in by_name_dict:
-                classinst = by_name_dict[name]
-            else:
-                interceptor_def = defs[name]
-
-                # Instantiate and put in by_name array
-                parts = interceptor_def["class"].split('.')
-                modpath = ".".join(parts[:-1])
-                classname = parts[-1]
-                module = __import__(modpath, fromlist=[classname])
-                classobj = getattr(module, classname)
-                classinst = classobj()
-
-                # Call configure
-                classinst.configure(config = interceptor_def["config"] if "config" in interceptor_def else None)
-
-                # Put in by_name_dict for possible re-use
-                by_name_dict[name] = classinst
-
-            interceptors[type_and_direction].append(classinst)
-
 class EndpointError(StandardError):
     pass
 
@@ -78,14 +45,23 @@ class EndpointUnit(object):
     channel = None
     _recv_greenlet = None
     _endpoint = None
+    _interceptors = None
 
-    def __init__(self, endpoint):
+    def __init__(self, endpoint=None, interceptors=None):
         self._endpoint = endpoint
+        self.interceptors = interceptors
 
     @property
     def interceptors(self):
+        if self._interceptors is not None:
+            return self._interceptors
+
         assert self._endpoint, "No endpoint attached"
         return self._endpoint.interceptors
+
+    @interceptors.setter
+    def interceptors(self, value):
+        self._interceptors = value
 
     def attach_channel(self, channel):
         log.debug("In EndpointUnit.attach_channel")
@@ -126,7 +102,7 @@ class EndpointUnit(object):
         @param  inv     An Invocation instance.
         @returns        A processed Invocation instance.
         """
-        inv_prime = process_interceptors(interceptors["message_incoming"] if "message_incoming" in interceptors else [], inv)
+        inv_prime = process_interceptors(self.interceptors["message_incoming"] if "message_incoming" in self.interceptors else [], inv)
         return inv_prime
 
     def message_received(self, msg, headers):
@@ -173,7 +149,7 @@ class EndpointUnit(object):
         @param  inv     An Invocation instance.
         @returns        A processed Invocation instance.
         """
-        inv_prime = process_interceptors(interceptors["message_outgoing"] if "message_outgoing" in interceptors else [], inv)
+        inv_prime = process_interceptors(self.interceptors["message_outgoing"] if "message_outgoing" in self.interceptors else [], inv)
         return inv_prime
 
     def spawn_listener(self):
@@ -259,6 +235,7 @@ class BaseEndpoint(object):
     # Endpoints
     # TODO: Make weakref or replace entirely
     endpoint_by_name = {}
+    _interceptors = None
 
     def __init__(self, node=None):
 
@@ -299,6 +276,18 @@ class BaseEndpoint(object):
             else:
                 raise EndpointError("Cannot pull node from Container.instance and no node specified")
 
+    @property
+    def interceptors(self):
+        if self._interceptors is not None:
+            return self._interceptors
+
+        assert self.node, "No node attached"
+        return self.node.interceptors
+
+    @interceptors.setter
+    def interceptors(self, value):
+        self._interceptors = value
+
     def create_endpoint(self, to_name=None, existing_channel=None, **kwargs):
         """
         @param  to_name     Either a string or a 2-tuple of (exchange, name)
@@ -309,7 +298,7 @@ class BaseEndpoint(object):
             self._ensure_node()
             ch = self._create_channel()
 
-        e = self.endpoint_unit_type(**kwargs)
+        e = self.endpoint_unit_type(endpoint=self, **kwargs)
         e.attach_channel(ch)
 
         return e
@@ -515,8 +504,8 @@ class SubscriberEndpointUnit(EndpointUnit):
     """
     @TODO: Should have routing mechanics, possibly shared with other listener endpoint types
     """
-    def __init__(self, callback):
-        EndpointUnit.__init__(self)
+    def __init__(self, callback, **kwargs):
+        EndpointUnit.__init__(self, **kwargs)
         self.set_callback(callback)
 
     def set_callback(self, callback):
@@ -893,7 +882,7 @@ class RPCClient(RequestResponseClient):
 
 class RPCResponseEndpointUnit(ResponseEndpointUnit):
     def __init__(self, routing_obj=None, **kwargs):
-        ResponseEndpointUnit.__init__(self)
+        ResponseEndpointUnit.__init__(self, **kwargs)
         self._routing_obj = routing_obj
         
     def _message_received(self, msg, headers):

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -77,6 +77,15 @@ class EndpointUnit(object):
 
     channel = None
     _recv_greenlet = None
+    _endpoint = None
+
+    def __init__(self, endpoint):
+        self._endpoint = endpoint
+
+    @property
+    def interceptors(self):
+        assert self._endpoint, "No endpoint attached"
+        return self._endpoint.interceptors
 
     def attach_channel(self, channel):
         log.debug("In EndpointUnit.attach_channel")

--- a/pyon/net/messaging.py
+++ b/pyon/net/messaging.py
@@ -15,8 +15,10 @@ from pyon.core.bootstrap import CFG
 from pyon.net import amqp
 from pyon.net import channel
 from pyon.util.async import blocking_cb
+from pyon.util.containers import for_name
 from pyon.util.log import log
 from pyon.util.pool import IDPool
+from collections import defaultdict
 
 class NodeB(amqp.Node):
     """
@@ -34,6 +36,8 @@ class NodeB(amqp.Node):
         self._pool = IDPool()
         self._bidir_pool = {}   # maps inactive/active our numbers (from self._pool) to channels
         self._pool_map = {}     # maps active pika channel numbers to our numbers (from self._pool)
+
+        self.interceptors = {}  # endpoint interceptors
 
         amqp.Node.__init__(self)
 
@@ -127,6 +131,35 @@ class NodeB(amqp.Node):
 
                 self._bidir_pool.pop(chid)
                 self._pool._ids_free.remove(chid)
+
+    def setup_interceptors(self, interceptor_cfg):
+        stack = interceptor_cfg["stack"]
+        defs = interceptor_cfg["interceptors"]
+
+        interceptors = defaultdict(list)
+
+        by_name_dict = {}
+        for type_and_direction in stack:
+            interceptor_names = stack[type_and_direction]
+            for name in interceptor_names:
+                if name in by_name_dict:
+                    classinst = by_name_dict[name]
+                else:
+                    interceptor_def = defs[name]
+
+                    # Instantiate and put in by_name array
+                    modpath, classname  = interceptor_def['class'].rsplit('.', 1)
+                    classinst           = for_name(modpath, classname)
+
+                    # Call configure
+                    classinst.configure(config = interceptor_def["config"] if "config" in interceptor_def else None)
+
+                    # Put in by_name_dict for possible re-use
+                    by_name_dict[name] = classinst
+
+                interceptors[type_and_direction].append(classinst)
+
+        self.interceptors = dict(interceptors)
 
 def ioloop(connection, name=None):
     # Loop until CTRL-C

--- a/pyon/net/test/test_endpoint.py
+++ b/pyon/net/test/test_endpoint.py
@@ -35,11 +35,10 @@ class TestError(StandardError):
     pass
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestEndpointUnit(PyonTestCase):
 
     def setUp(self):
-        self._endpoint_unit = EndpointUnit()
+        self._endpoint_unit = EndpointUnit(interceptors={})
 
     def test_attach_channel(self):
         ch = Mock(spec=BaseChannel)
@@ -116,7 +115,6 @@ class TestEndpointUnit(PyonTestCase):
         self.assertTrue(self._endpoint_unit.message_received.called)
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestBaseEndpoint(PyonTestCase):
     def setUp(self):
         self._node = Mock(spec=NodeB)
@@ -193,7 +191,6 @@ class TestBaseEndpoint(PyonTestCase):
         # well, it's just a pass, so nothing happens/there for us to test
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestSendingBaseEndpoint(PyonTestCase):
     def test_init(self):
         ep = SendingBaseEndpoint(node=sentinel.node)
@@ -390,7 +387,6 @@ class TestListeningBaseEndpointInt(IonIntegrationTestCase):
         gl2.join(timeout=5)
 
 
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 @attr('UNIT')
 class TestPublisher(PyonTestCase):
     def setUp(self):
@@ -398,6 +394,7 @@ class TestPublisher(PyonTestCase):
         self._pub = Publisher(node=self._node, to_name="testpub")
         self._ch = Mock(spec=SendChannel)
         self._node.channel.return_value = self._ch
+        self._node.interceptors = {}
 
     def test_publish(self):
         self.assertEquals(self._node.channel.call_count, 0)
@@ -459,11 +456,11 @@ class RecvMockMixin(object):
         return ch
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestSubscriber(PyonTestCase, RecvMockMixin):
 
     def setUp(self):
         self._node = Mock(spec=NodeB)
+        self._node.interceptors = {}
 
     def test_create_sub_without_callback(self):
         self.assertRaises(AssertionError, Subscriber, node=self._node, from_name="testsub")
@@ -478,10 +475,8 @@ class TestSubscriber(PyonTestCase, RecvMockMixin):
         self.assertEquals(e._callback, mycb)
 
     def test_subscribe(self):
-        """
-        Test Subscriber.
-        The goal of this test is to get messages routed to the callback mock.
-        """
+        #Test Subscriber.
+        #The goal of this test is to get messages routed to the callback mock.
         cbmock = Mock()
         sub = Subscriber(node=self._node, from_name="testsub", callback=cbmock)
 
@@ -499,13 +494,12 @@ class TestSubscriber(PyonTestCase, RecvMockMixin):
         cbmock.assert_called_once_with('subbed', {'status_code':200, 'error_message':'', 'op': None})
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestRequestResponse(PyonTestCase, RecvMockMixin):
     def setUp(self):
         self._node = Mock(spec=NodeB)
 
     def test_endpoint_send(self):
-        e = RequestEndpointUnit()
+        e = RequestEndpointUnit(interceptors={})
         ch = self._setup_mock_channel()
         e.attach_channel(ch)
 
@@ -528,6 +522,7 @@ class TestRequestResponse(PyonTestCase, RecvMockMixin):
         """
         rr = RequestResponseClient(node=self._node, to_name="rr")
         rr.node.channel.return_value = self._setup_mock_channel()
+        rr.node.interceptors = {}
 
         ret = rr.request("request")
         self.assertEquals(ret, "bidirmsg")
@@ -555,7 +550,6 @@ class SimpleService(BaseService):
         return True
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
 
     def test_build_msg(self):
@@ -567,7 +561,7 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
         self.assertNotEquals(str(msg), str(fakemsg))
 
     def test_endpoint_send(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         ch = self._setup_mock_channel()
         e.attach_channel(ch)
 
@@ -580,48 +574,48 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
         errlist = [exception.BadRequest, exception.Unauthorized, exception.NotFound, exception.Timeout, exception.Conflict, exception.ServerError, exception.ServiceUnavailable]
 
         for err in errlist:
-            e = RPCRequestEndpointUnit()
+            e = RPCRequestEndpointUnit(interceptors={})
             ch = self._setup_mock_channel(status_code=err.status_code, error_message=str(err.status_code))
             e.attach_channel(ch)
 
             self.assertRaises(err, e.send, 'payload')
 
     def test__raise_exception_known(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         self.assertRaises(exception.NotFound, e._raise_exception, 404, "no")
 
     def test__raise_exception_unknown(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         self.assertRaises(exception.ServerError, e._raise_exception, 999, "no")
 
     @patch('pyon.net.endpoint.RequestEndpointUnit._send', Mock(side_effect=exception.Timeout))
     def test_timeout_makes_sflow_sample(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         e._sample_request = Mock()
 
         self.assertRaises(exception.Timeout, e._send, sentinel.msg, sentinel.headers, timeout=1)
         e._sample_request.assert_called_once_with(-1, 'Timeout', sentinel.msg, sentinel.headers, '', {})
 
     def test__get_sample_name(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         self.assertEquals(e._get_sample_name(), "unknown-rpc-client")
 
     def test__get_sflow_manager(self):
         Container.instance = None
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         self.assertIsNone(e._get_sflow_manager())
 
     def test__get_sflow_manager_with_container(self):
         Container.instance = None
         c = Container()     # ensure an instance
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
         self.assertEquals(e._get_sflow_manager(), c.sflow_manager)
 
         Container.instance = None
 
     @patch('pyon.net.endpoint.time.time', Mock(return_value=1))
     def test__build_sample(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
 
         heads = {'conv-id': sentinel.conv_id,
                  'ts': '1',
@@ -646,7 +640,7 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
                                 })
 
     def test__build_sample_uses_last_name_for_op(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
 
         heads = {'conv-id': sentinel.conv_id,
                  'ts': '1',
@@ -662,7 +656,7 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
 
     @patch.dict('pyon.net.endpoint.CFG', {'container':{'sflow':{'enabled':True}}})
     def test__sample_request(self):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
 
         e._get_sflow_manager = Mock(return_value=Mock(spec=SFlowManager))
         e._get_sflow_manager.return_value.should_sample = True
@@ -678,7 +672,7 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
     @patch.dict('pyon.net.endpoint.CFG', {'container':{'sflow':{'enabled':True}}})
     @patch('pyon.net.endpoint.log')
     def test__sample_request_no_sample(self, mocklog):
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
 
         e._get_sflow_manager = Mock(return_value=Mock(spec=SFlowManager))
         e._get_sflow_manager.return_value.should_sample = False
@@ -693,7 +687,7 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
     @patch('pyon.net.endpoint.log')
     def test__sample_request_exception(self, mocklog):
 
-        e = RPCRequestEndpointUnit()
+        e = RPCRequestEndpointUnit(interceptors={})
 
         e._get_sflow_manager = Mock(return_value=Mock(spec=SFlowManager))
         e._get_sflow_manager.return_value.should_sample = True
@@ -704,7 +698,6 @@ class TestRPCRequestEndpoint(PyonTestCase, RecvMockMixin):
         mocklog.exception.assert_called_once_with("Could not sample, ignoring")
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestRPCClient(PyonTestCase, RecvMockMixin):
 
     @patch('pyon.net.endpoint.IonObject')
@@ -713,6 +706,7 @@ class TestRPCClient(PyonTestCase, RecvMockMixin):
 
         rpcc = RPCClient(node=node, to_name="simply", iface=ISimpleInterface)
         rpcc.node.channel.return_value = self._setup_mock_channel()
+        rpcc.node.interceptors = {}
 
         self.assertTrue(hasattr(rpcc, 'simple'))
 
@@ -726,7 +720,6 @@ class TestRPCClient(PyonTestCase, RecvMockMixin):
         self.assertRaises(AssertionError, rpcc.simple, "zap", "zip")
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
 
     def simple(self, named=None):
@@ -744,12 +737,12 @@ class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
                 self.named = ["ein", "zwei"]
         cvalue = FakeMsg()
 
-        e = RPCResponseEndpointUnit(routing_obj=self)
+        e = RPCResponseEndpointUnit(routing_obj=self, interceptors={})
         ch = self._setup_mock_channel(value=cvalue, op="simple")
         e.attach_channel(ch)
 
         e.spawn_listener()
-        args = self._ar.get()
+        args = self._ar.get(timeout=10)
 
         self.assertEquals(args, ["ein", "zwei"])
 
@@ -761,7 +754,7 @@ class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
                 self.named = ["ein", "zwei"]
         cvalue = FakeMsg()
 
-        e = RPCResponseEndpointUnit(routing_obj=self)
+        e = RPCResponseEndpointUnit(routing_obj=self, interceptors={})
         ch = self._setup_mock_channel(value=cvalue, op="no_exist")
         e.attach_channel(ch)
 
@@ -790,7 +783,7 @@ class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
                 self.not_named = ["ein", "zwei"]
         cvalue = FakeMsg()
 
-        e = RPCResponseEndpointUnit(routing_obj=self)
+        e = RPCResponseEndpointUnit(routing_obj=self, interceptors={})
         ch = self._setup_mock_channel(value=cvalue, op="simple")
         e.attach_channel(ch)
 
@@ -841,7 +834,7 @@ class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
             pass
         cvalue = FakeMsg()
 
-        e = RPCResponseEndpointUnit(routing_obj=self)
+        e = RPCResponseEndpointUnit(routing_obj=self, interceptors={})
         ch = self._setup_mock_channel(value=cvalue, op="error_op")
         e.attach_channel(ch)
 
@@ -873,13 +866,13 @@ class TestRPCResponseEndpoint(PyonTestCase, RecvMockMixin):
         self.assertRaises(exception.BadRequest, e.message_received, 3, {})
 
 @attr('UNIT')
-@patch.dict(endpoint.interceptors, no_interceptors, clear=True)
 class TestRPCServer(PyonTestCase, RecvMockMixin):
 
     def test_rpc_server(self):
         node = Mock(spec=NodeB)
         svc = SimpleService()
         rpcs = RPCServer(node=node, from_name="testrpc", service=svc)
+        node.interceptors = {}
 
         # build a command object to be returned by the mocked channel
         class FakeMsg(object):


### PR DESCRIPTION
Removes module initialization for interceptors, cleans a variety of things up.

Interceptors belong to the Node, because Endpoints can be used outside of a Container.  They are initialized on startup (Exchange Manager start), and propagate to all Endpoint/EndpointUnit.

Endpoints expose the interceptors through properties on themselves, where they can either be set on a per endpoint/endpoint unit level, or just take the system default. This is very flexible in operation.
