### PR TITLE
2012 06 12 pycc refactor

### DIFF
--- a/pyon/core/bootstrap.py
+++ b/pyon/core/bootstrap.py
@@ -105,7 +105,9 @@ def is_testing():
 
 def set_sys_name(sysname=None):
     global sys_name
+    old_sys_name = sys_name
     sys_name = sysname
+    print "pyon: sys_name changed from '%s' to '%s'" % (old_sys_name, sys_name)
 
 def get_sys_name():
     if sys_name:
@@ -137,8 +139,10 @@ def bootstrap_pyon(logging_config_override=None, pyon_cfg=None):
     """
     This function initializes the core elements of the Pyon framework in a controlled way.
     It does not initialize the ION container or the ION system.
+    @param logging_config_override  A dict to initialize the Python logging subsystem (None loads default files)
+    @param pyon_cfg   A DotDict with the fully loaded pyon configuration to set as CFG (None loads default files)
     """
-    print "pyon: pyon.bootstrap executing..."
+    print "pyon: pyon.bootstrap (bootstrap_pyon) executing..."
 
     # Make sure Pyon is only initialized only once
     global pyon_initialized
@@ -146,7 +150,7 @@ def bootstrap_pyon(logging_config_override=None, pyon_cfg=None):
         print "pyon: WARNING -- bootstrap_pyon() called again!"
         return
 
-    # ENVIRONMENT. Check we are called like expected
+    # ENVIRONMENT. Check we are called in an expected environment (files, directories, etc)
     assert_environment()
 
     # LOGGING. Initialize logging from config
@@ -159,22 +163,20 @@ def bootstrap_pyon(logging_config_override=None, pyon_cfg=None):
     # CONFIG. Initialize pyon global configuration from local files
     set_config(pyon_cfg)
 
-    from pyon.core.registry import IonObjectRegistry
-    from pyon.service.service import IonServiceRegistry
-
     # OBJECTS. Object and message definitions.
-    global _obj_registry, _service_registry
+    from pyon.core.registry import IonObjectRegistry
+    global _obj_registry
     _obj_registry = IonObjectRegistry()
-    #IonObject = _obj_registry.new
-
-    _obj_registry.validate_setattr = CFG.validate.setattr
 
     # SERVICES. Service definitions
+    from pyon.service.service import IonServiceRegistry
+    global _service_registry
     _service_registry = IonServiceRegistry()
     _service_registry.load_service_mods('interface/services')
     _service_registry.build_service_map()
 
     # INTERCEPTORS.
+    # TODO: Is
     from pyon.net.endpoint import instantiate_interceptors
     instantiate_interceptors(CFG.interceptor)
 
@@ -184,4 +186,3 @@ def bootstrap_pyon(logging_config_override=None, pyon_cfg=None):
 
     # Set initialized flag
     pyon_initialized = True
-

--- a/pyon/core/config.py
+++ b/pyon/core/config.py
@@ -37,7 +37,7 @@ def apply_remote_config(system_cfg):
     from pyon.core.bootstrap import get_sys_name
     from pyon.core.exception import Conflict
     from pyon.ion.directory_standalone import DirectoryStandalone
-    directory = DirectoryStandalone(sysname=get_sys_name(), config=bootstrap_config)
+    directory = DirectoryStandalone(sysname=get_sys_name(), config=system_cfg)
 
     de = directory.lookup("/Config/CFG")
     if not de:
@@ -85,6 +85,7 @@ def _bootstrap_service_defs(directory):
     directory.register_mult(svc_list)
 
 def auto_bootstrap_config(bootstrap_config, system_cfg):
+    print "pyon: config: Auto bootstrap CFG into directory"
     from pyon.core.bootstrap import get_sys_name
     from pyon.ion.directory_standalone import DirectoryStandalone
     directory = DirectoryStandalone(sysname=get_sys_name(), config=bootstrap_config)
@@ -93,6 +94,7 @@ def auto_bootstrap_config(bootstrap_config, system_cfg):
         directory.register("/Config", "CFG", **system_cfg.copy())
 
 def auto_bootstrap_interfaces(bootstrap_config):
+    print "pyon: config: Auto bootstrap interfaces into directory"
     from pyon.core.bootstrap import get_sys_name
     from pyon.ion.directory_standalone import DirectoryStandalone
     directory = DirectoryStandalone(sysname=get_sys_name(), config=bootstrap_config)

--- a/pyon/core/registry.py
+++ b/pyon/core/registry.py
@@ -108,7 +108,8 @@ class IonObjectRegistry(object):
         for name, clzz in classes:
             message_classes[name] = clzz
 
-
+        from pyon.core.bootstrap import CFG
+        self.validate_setattr = CFG.get_safe('validate.setattr', False)
 
     def new(self, _def, _dict=None, **kwargs):
         """ See get_def() for definition lookup options. """

--- a/pyon/datastore/couchdb/couchdb_standalone.py
+++ b/pyon/datastore/couchdb/couchdb_standalone.py
@@ -18,7 +18,7 @@ class CouchdbStandalone(object):
         self.database_url = "http://" + self.authentication + self.host + ":" + self.port
         self.server = None
         self.database = None
-        self.database_name = database_name.lower()
+        self.database_name = database_name.lower() if database_name else None
 
         self._connect()
 

--- a/scripts/pycc.py
+++ b/scripts/pycc.py
@@ -105,15 +105,16 @@ def main(opts, *args, **kwargs):
             # Load minimal bootstrap config if option "config_from_directory"
             bootstrap_config = config.read_local_configuration(['res/config/pyon_min_boot.yml'])
             config.apply_local_configuration(bootstrap_config, pyon.DEFAULT_LOCAL_CONFIG_PATHS)
+            config.apply_configuration(bootstrap_config, kwargs)
             print "pycc: config_from_directory=True. Minimal bootstrap configuration:", bootstrap_config
         else:
             # Otherwise: Set to standard set of local config files just so that we have something
             bootstrap_config = pyon_config
 
-        # @TODO Remove special case for testing: just use system.name instead as before
-        if bootstrap_config.get_safe("system.testing_sysname", None):
-            testing_sysname = bootstrap_config.get_safe("system.testing_sysname", None)
-            bootstrap.set_sys_name(testing_sysname)
+        # Override sysname from config file or command line
+        if not opts.sysname and bootstrap_config.get_safe("system.name", None):
+            new_sysname = bootstrap_config.get_safe("system.name")
+            bootstrap.set_sys_name(new_sysname)
 
         # Delete sysname datastores if option "force_clean" is set
         if opts.force_clean:


### PR DESCRIPTION
@Dave or Jamie

Bring in the refactoring of pycc and configuration. See also ion-definitions and coi-services fix.

Summary of changes:
- Move CFG loading from container into the pycc program
- Made pyon initialization explicitly called and not depend on static initialization
- Removed many static initializers and referenced global variables
- Standalone datastore for pycc
- Force_clean is argument of pycc not config
- Added system.name back to configuration
