### PR TITLE
adding DB repository layers

### DIFF
--- a/pyon/datastore/couchdb/couch_pool.py
+++ b/pyon/datastore/couchdb/couch_pool.py
@@ -1,0 +1,25 @@
+from pyon.core.bootstrap import get_sys_name
+from pyon.datastore.couchdb.couch_store import CouchStore
+from pyon.datastore.pool import Pool
+
+class CouchDBPoolDict(dict):
+    """ acts like a dictionary of Pool, but creates new Pools dynamically as needed """
+    def __init__(self, prefix=get_sys_name()+'_', expected_connections=None, max_connections=None, **kw):
+        super(CouchDBPoolDict,self).__init__()
+        self.prefix = prefix
+        # split keyword args between those passed to Pool()
+        self.pool_args = {}
+        if expected_connections:
+            self.pool_args['expected_connections']=expected_connections
+        if max_connections:
+            self.pool_args['max_connections']=max_connections
+        # and those passed to CouchStore()
+        self.db_args = kw
+
+    def __getitem__(self, name):
+        if name in self.keys():
+            return super(CouchDBPoolDict,self).__getitem__(name)
+        factory_method=lambda name: CouchStore(self.prefix+name, **self.db_args)
+        pool = Pool(name, factory_method=factory_method, **self.pool_args)
+        self.__setitem__(name, pool)
+        return pool

--- a/pyon/datastore/couchdb/couch_store.py
+++ b/pyon/datastore/couchdb/couch_store.py
@@ -1,0 +1,220 @@
+""" WORK IN PROGRESS:  eventual goal is to have this class perform all couchdb operations and be completely unaware of Ion-specific objects or container-specific settings
+
+    responsible for:
+    - operations accept single or list of objects or ids as appropriate
+    - return types are generally tuple or list of tuple: (success, id, object)
+
+"""
+
+from couchdb import Server
+from couchdb.http import ResourceConflict, ResourceNotFound
+from pyon.core.exception import BadRequest, Conflict, NotFound, ServerError
+from pyon.util.log import log
+
+class CouchStore(object):
+    """ represents one couch DB instance """
+    def __init__(self, instance, server='localhost', port=5984, username=None, password=None, can_create=False, must_create=False, max_retry=2):
+        self._url = 'http://%s:%s@%s:%d' % (username, password, server, port) \
+                    if username else 'http://%s:%d' % (server, port)
+        self._db_name = instance
+        self._server_name = server
+        self._max_retry = max_retry
+
+        self._server = Server(self._url)
+        if can_create or must_create:
+            try:
+                log.debug('creating %s on %s', instance, self._url)
+                self._db = self._server.create(self._db_name)
+            except Exception,e:
+                if must_create:
+                    raise self._wrap_error('initialize',self._db_name,e)
+        else:
+            log.debug('connecting to %s on %s', instance, server)
+            self._db = self._server[self._db_name]
+
+    def drop(self):
+        log.debug('deleting %s from %s', self._db_name, self._server_name)
+        self._server.delete(self._db_name)
+        self._db = None
+
+    def _is_list(self, op, target):
+        # check that argument is string, dictionary or list of ONE of them
+        if isinstance(target, str) or isinstance(target, dict):
+            return False
+        elif all(isinstance(t, str) for t in target) or all(isinstance(t, dict) for t in target):
+            return True
+        else:
+            BadRequest('CouchDB '+op+' takes string, dictionary or list of one of them')
+
+    # check that arg, or if list all items in arg, have _rev attribute (expected=True) or do not have (expected=False)
+    def _check_attr(self, arg, name, expected):
+        if isinstance(arg, dict):
+            return (name in arg.keys())==expected
+        items = [ name in item.keys() for item in arg ]
+        if expected:
+            return reduce(lambda a,b: a and b, items)
+        else:
+            return not reduce(lambda a,b: a or b, items)
+
+    def _wrap_error(self, op, id, ex):
+        return ServerError('CouchDB %s of object %s failed with error %s(%s)'%(op,id,type(ex).__name__,str(ex)))
+
+    def insert(self, target):
+        """ insert one or many entries.  must have _id and must not have _rev
+
+            if target is a list, docs are updated with _rev, but not if target is dict
+            (side effect of underlying library)
+
+            returns tuple (success, _id, Exception) when target is a dictionary
+            returns list of tuples when target is a list
+
+        """
+        if not self._check_attr(target, '_rev', False):
+            raise Conflict('cannot insert document with revision')
+        if not self._check_attr(target, '_id', True):
+            raise BadRequest('inserted documents must have _id')
+
+        if isinstance(target, list):
+            return self._db.update(target)
+        else:
+            id = target['_id']
+            try:
+                self._db.create(target)
+                return True, id, None
+            except ResourceConflict, e:
+                return False, id, BadRequest('Object with id %s already exists'%id)
+            except Exception, e:
+                return False, id, self._wrap_error('insert',id,e)
+
+    # TODO: repository can raise exception if don't read all docs
+    def read(self, target):
+        """ read one or many entries """
+        if isinstance(target, list):
+            ids = [ t['_id'] if isinstance(t,dict) else t for t in target ]
+            rows = self._db.view('_all_docs', keys=ids, include_docs=True)
+            return [ (row.doc is not None, row.id, row.doc) for row in rows ]
+
+        # else target is an id
+        id = target['_id'] if isinstance(target, dict) else target
+        try:
+            doc = self._db[id]
+            return doc is not None, id, doc
+        except ResourceNotFound:
+            return False, id, NotFound('Object %s does not exist'%id)
+        except Exception,e:
+            return False, id, self._wrap_error('read',id,e)
+
+    def update(self, target, force=False, _depth=0):
+        """ update one or many entries
+
+            if force is False and _rev is missing or not the latest, the update will fail.
+            if force is True and _rev is missing or not the latest, will find the latest _rev and attempt to update.
+            since others may be updating at the same time, this may still not be the latest!
+            update will repeat up to max_retry times before giving up.
+
+            return value for a single item update is a tuple (success, id, exception)
+            return value when target is a list is a list of tuples indicating the outcome of each item updated.
+
+            NOTE: updates may not made to DB in order.
+        """
+        if not isinstance(target, list):
+            result = self.update([target], force=force)
+            return result[0]
+
+        # update the ones that already have revisions
+        have_revisions = filter(lambda d: '_rev' in d.keys(), target)
+        results = self._db.update(have_revisions) if len(have_revisions) else None
+
+        # if missing or old _rev, retry update
+        log.debug('update results: %s', repr(results))
+        some_attempted = len(have_revisions)>0
+        some_failed = some_attempted and not reduce(lambda a,b: a and b, [r[0] for r in results])
+        some_not_updated = len(have_revisions)<len(target) or some_failed
+        can_retry = force and _depth<self._max_retry
+        if can_retry and some_not_updated:
+            # start with elements that did not have _rev
+            retry_target = filter(lambda d: '_rev' not in d.keys(), target)
+            # now add elements that failed due to wrong _rev
+            successful_results = []
+            if results:
+                doc_with_result = zip(have_revisions, results)
+                failed_subset_with_result = filter(lambda t: not t[1][0], doc_with_result)  # TODO: also check t[1][2] is correct exception type for bad _rev
+                retry_target += [ t[0] for t in failed_subset_with_result ]
+                successful_results = [ t[1] for t in filter(lambda t: t[1][0], doc_with_result) ]
+            # search db and update these _rev values
+            log.debug(' before %s', repr(retry_target))
+            self._update_revision(retry_target)
+            log.debug('  after %s', repr(retry_target))
+            # some just aren't in the DB any more
+            not_found_docs = filter(lambda t: '_rev' not in t, retry_target)
+            not_found_results = [ (False, t['_id'], Exception('not found in DB')) for t in not_found_docs ] #TODO: use application exception
+            # for otehrs, try again with udpated _rev
+            found_rev = filter(lambda t: '_rev' in t, retry_target)
+            retry_results = self.update(found_rev, force=True, _depth=_depth+1)
+
+            results = not_found_results + retry_results + successful_results
+
+        # only need to sort once on final exit from recursive retry
+        if _depth>1:
+            return results
+
+        # sort results into original order of arguments
+        out = []
+        for d in target:
+            id = d['_id']
+            result = None
+            if results:
+                for t in results:
+                    if t[1]==id:
+                        result = t
+                        break
+            if not result:   # no revision?
+                if force:    #   force: would have read latest from DB -- so _id was not found
+                    result = (False, id, Exception("udpate failed: _id was not found"))
+                else:        #   no force: then cannot update
+                    result = (False, id, Exception("update failed without _rev or force"))
+            out.append(result)
+        return out
+
+    def _update_revision(self, target):
+        # update dictionaries to have the latest _rev from the DB
+        ids = [ d['_id'] for d in target ]
+        results = self._db.view('_all_docs', keys=ids)
+        for result in results:
+            id = result.id
+            for d in target:
+                if d['_id']==id:
+                    d['_rev'] = result.value['rev']
+                    break
+
+    def delete(self, target, force=False):
+        """ delete one more multiple entries """
+        is_list = self._is_list('delete', target)
+        is_ids = isinstance(target[0],str) if is_list else isinstance(target,str)
+
+        # convert arg into list of dictionaries with _id, _delete=True and optionally _rev
+        if is_ids:
+            if is_list:
+                # list of ids
+                dicts = [ { '_id':t, '_deleted':True} for t in target ]
+            else:
+                # single id
+                dicts = { '_id':target, '_deleted':True}
+        else:
+            # TODO: smaller delete if only pass _id, _rev and _deleted (drop other entries in dict)
+            dicts = target
+            if is_list:
+                # list of dictionaries
+                for t in target:
+                    t['_deleted']=True
+            else:
+                # single dictionary
+                dicts['_deleted']=True
+
+        return self.update(dicts, force=force or is_ids)
+
+    def create_view(self):
+        pass
+
+    def query_view(self):
+        pass

--- a/pyon/datastore/couchdb/test/__init__.py
+++ b/pyon/datastore/couchdb/test/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'newbro'

--- a/pyon/datastore/couchdb/test/test_couch_store.py
+++ b/pyon/datastore/couchdb/test/test_couch_store.py
@@ -1,0 +1,126 @@
+
+from pyon.datastore.couchdb.couch_store import CouchStore
+from pyon.util.int_test import IonIntegrationTestCase
+from nose.plugins.attrib import attr
+from pyon.util.log import log
+from pyon.core.bootstrap import CFG
+
+@attr('INT', group='datastore')
+class TestCouchStore(IonIntegrationTestCase):
+    def setUp(self):
+        log.debug("cfg %s", repr(CFG['server'].keys()))
+        server=CFG['server']['couchdb']['host']
+        username=CFG['server']['couchdb']['username']
+        password=CFG['server']['couchdb']['password']
+        self.subject = CouchStore('test-db', server, username=username, password=password, can_create=True)
+
+    def tearDown(self):
+        self.subject.drop()
+
+    def testCreateDrop(self):
+        pass
+
+    def testInsertRead(self):
+        # insert single
+        doc = { 'a':'1', 'b':'2', '_id':'1' }
+        self.subject.insert(doc)
+#        self.assertTrue('_rev' in doc.keys())
+        succ,id,doc_out = self.subject.read('1')
+        for key in doc.keys():
+            self.assertEquals(doc[key], doc_out[key])
+        self.assertTrue('_rev' in doc_out.keys(), msg=repr(doc_out.keys()))
+
+        # insert list
+        docs = [ { 'a':'1', 'b':'2', '_id':'2' },
+                 { 'a':'1', 'b':'2', '_id':'3' } ]
+        self.subject.insert(docs)
+        docs_out = self.subject.read(['3','1','2'])
+        doc_in = docs[1]
+        succ,id,doc_out = docs_out[0]
+        for key in doc_in.keys():
+            self.assertEquals(doc_in[key], doc_out[key], msg='out=%s'%repr(doc_out))
+
+        # insert duplicate
+        out = self.subject.insert(doc)
+        self.assertFalse(out[0])
+        docs = [ { 'a':'1', 'b':'2', '_id':'0' },
+                 { 'a':'1', 'b':'2', '_id':'2' }, # duplicate ID
+                 { 'a':'1', 'b':'2', '_id':'5' } ]
+        out = self.subject.insert(docs)
+        self.assertTrue(out[0][0])
+        self.assertFalse(out[1][0])
+        self.assertTrue(out[2][0])
+
+
+
+    def testUpdate(self):
+        docs = [ { 'a':'1', 'b':'2', '_id':'2' },
+                 { 'a':'1', 'b':'2', '_id':'3' } ]
+        self.subject.insert(docs)
+        self.assertTrue('_rev' in docs[0])  # couchdb library updates dictionary!
+
+        # normal update should succeed
+        docs[0]['a'] = 'changed'
+        docs[1]['b'] = 'changed'
+        out = self.subject.update(docs)
+        self.assertTrue(out[0][0])
+        self.assertTrue(out[1][0])
+
+        # missing or wrong _rev and update should fail
+        del(docs[0]['_rev'])
+        #                  1-1d11ff1d76bfac091a6ca550c9d0863d
+        docs[1]['_rev'] = '1-1d11ff1d76bfac091a6ca550c9d0863e'
+
+        out = self.subject.update(docs)
+        self.assertFalse(out[0][0])
+        self.assertFalse(out[1][0])
+
+        # with force, should find and update latest revision
+        out = self.subject.update(docs, force=True)
+        self.assertTrue(out[0][0])
+        self.assertTrue(out[1][0])
+
+        # doc not in DB should fail
+        doc = { 'a':'1', '_id':5 }
+        out = self.subject.update(doc)
+        self.assertFalse(out[0])
+
+    def testDelete(self):
+        docs = [ { 'a':'1', 'b':'2', '_id':'1' },
+                 { 'a':'1', 'b':'2', '_id':'2' },
+                 { 'a':'1', 'b':'2', '_id':'3' },
+                 { 'a':'1', 'b':'2', '_id':'4' },
+                 { 'a':'1', 'b':'2', '_id':'5' } ]
+        self.subject.insert(docs)
+
+        self.subject.delete(['2','3','4'])
+        try:
+            succ,id,doc = self.subject.read('3')
+        except Exception,e:
+            log.error('throws', exc_info=True)
+            self.fail('should return, not raise exception %s'%str(e))
+        self.assertFalse(succ, msg="should not be able to read deleted doc")
+
+        docs = [ { 'a':'1', 'b':'2', '_id':'1' },
+                 { 'a':'1', 'b':'2', '_id':'2' },
+                 { 'a':'1', 'b':'2', '_id':'3' },
+                 { 'a':'1', 'b':'2', '_id':'4' },
+                 { 'a':'1', 'b':'2', '_id':'5' } ]
+        self.subject.insert(docs)
+        out = self.subject.delete(['0','3','6'])
+        self.assertFalse(out[0][0])
+        self.assertTrue(out[1][0])
+        self.assertFalse(out[2][0])
+
+
+    def testAttr(self):
+        docYY = { '_id': 'a', '_rev': 'a' }
+        docYN = { '_id': 'a'              }
+        docNY = {             '_rev': 'a' }
+        docNN = {                         }
+
+        self.assertTrue(self.subject._check_attr( [docYY, docYN], '_id', True))
+        self.assertFalse(self.subject._check_attr( [docYY, docNY, docYN], '_id', True))
+        self.assertTrue(self.subject._check_attr( [docNY,docNN], '_id', False))
+        self.assertFalse(self.subject._check_attr( [docNY,docYN,docNN], '_id', False))
+

--- a/pyon/datastore/id_factory.py
+++ b/pyon/datastore/id_factory.py
@@ -1,0 +1,70 @@
+""" create minimal-length, increasing IDs for couchdb """
+from threading import Lock
+from uuid import uuid4
+from time import time
+from random import choice
+
+class IDFactory(object):
+    def create_id(self):
+        pass
+
+class RandomIDFactory(IDFactory):
+    def create_id(self):
+        return uuid4().hex
+
+class SaltedTimeIDFactory(IDFactory):
+    """ generator for minimal-length, increasing ID values for couchdb
+
+        ID is base64-encoded sequence of bits [ 42-bit time + random salt ]
+
+        salt is saved and reused until a duplicate is reported.
+        a duplicate can occur if two containers choose the same salt and perform an operation at the same (millisec) time.
+        the likelyhood that no two systems out of N choose the same B-bit salt value is given by:
+            [ (2^B - 1) / 2^B ] ^ [N * (N-1) / 2]
+        with 14 bit salt values, this is 99% for 20 systems, 93% for 50 systems, 74% for 100 systems
+        [ we only need to consider the number of systems providing RPC services -- not all nodes in the system ]
+
+        if a duplicate occurs, the generator can change the salt and try again.  likelyhood of any one new salt matching
+        another existing value for even large networks is extremely small.
+
+        DB operations should get and attempt to save documents with the generated ID value, but be prepared to
+        catch DB exceptions indicating duplicate ID, then replace and try again.
+    """
+
+    # chars are in ascii order to maintain ID sequence order
+    _CHARSET="-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
+
+    def __init__(self, salt_chars=3):
+        self._salt_chars = salt_chars
+        self._change_salt()
+        self._lock = Lock()
+        self._last_time = 0
+
+    def _change_salt(self):
+        self._salt = [ choice(self._CHARSET) for n in xrange(self._salt_chars) ]
+
+    def create_id(self):
+#        buffer = bytearray((self._salt_bits + 42)/8)
+        time_value = int(time()*1000) # 42bit millisecond value overflows ~ 2112
+
+        # there is a slight chance that two IDs are reqeusted within a millisecond
+        # if so, increment the time by one MS.
+        self._lock.acquire()
+        if time_value<=self._last_time:
+            time_value = self._last_time+1
+        self._last_time = time_value
+        self._lock.release()
+
+        # explicit base64 encoding used b/c our charset differs and time doesn't fall on nice byte boundaries
+        bits_used = 0
+        id_chars = self._salt[:]
+        while bits_used<42:
+            low_six_bits = time_value & 63
+            id_chars[0:0] = self._CHARSET[low_six_bits]
+            time_value /= 64
+            bits_used += 6
+        return ''.join(id_chars)
+
+    def replace_duplicate(self):
+        self._change_salt()
+        return self.create_id()

--- a/pyon/datastore/pool.py
+++ b/pyon/datastore/pool.py
@@ -1,0 +1,75 @@
+""" general pooling mechanism, although slightly tailored to DB connections """
+
+from threading import Lock
+from pyon.core.exception import ServerError, BadRequest
+from pyon.util.log import log
+
+class Pool(object):
+    def __init__(self, name, factory_method=None, expected_connections=5, max_connections=10):
+        """ create a new pool that uses the callable factory_method to create new connections
+            will emit warnings if more than expected_connections are active,
+            will fail if request would cause more than max_connections to be active.
+        """
+        self._name = name
+        self._lock = Lock()
+        self._create_object = factory_method or self.create_object
+        self._expected = expected_connections
+        self._max = max_connections
+        self._unused = []
+        self._used = []
+        self._close = None
+
+    def check_out(self):
+        """ check a connection out of the pool or create one if necessary """
+        self._lock.acquire()
+        try:
+            if self._close:
+                raise ServerError('system shutting down')
+            if len(self._unused):
+                out = self._unused[0]
+                del self._unused[0]
+            else:
+                count = len(self._used)
+                if count>=self._max:
+                    raise BadRequest('already have max connections for ' + self._name)
+                elif count>self._expected:
+                    log.warn('exceeding expected number of DB connections for ' + self._name + ': ' + str(count))
+                out = self._create_object(self._name)
+            self._used.append(out)
+            return out
+        finally:
+            self._lock.release()
+    def check_in(self, obj):
+        """ return a connection to the pool """
+        self._lock.acquire()
+        try:
+            self._used.remove(obj)
+            if self._close:
+                try:
+                    self._close(obj)
+                except:
+                    log.warn('exception in close operation', exc_info=True)
+            else:
+                self._unused.append(obj)
+        finally:
+            self._lock.release()
+    def create_object(self, obj):
+        raise NotImplementedError('should be implemented by subclass')
+
+    def destroy_object(self, obj):
+        """ return a connection, but don't allow it to be reused (ie- connection has been closed) """
+        self._lock.acquire()
+        try:
+            self._used.remove(obj)
+        finally:
+            self._lock.release()
+    def shut_down(self, op=None, interrupt=False):
+        """ allow no more objects to be created, invoke op on all objects now or wait for check_in """
+        self._close = op
+        if interrupt:
+            # make copy so checkins won't update list while iterating
+            for o in [ o for o in self._used ]:
+                try:
+                    op(o)
+                except:
+                    log.warn('exception in close operation', exc_info=True)

--- a/pyon/datastore/repository.py
+++ b/pyon/datastore/repository.py
@@ -1,0 +1,152 @@
+"""
+
+"""
+
+from pyon.core.exception import IonException, ServerError, BadRequest, NotFound
+from pyon.core.object import IonObjectSerializer, IonObjectDeserializer, IonObjectBase
+from pyon.datastore.id_factory import SaltedTimeIDFactory
+from pyon.ion.resource import AT
+from pyon.util.containers import DotDict, get_ion_ts, get_safe
+from pyon.util.log import log
+from pyon.datastore.pool import Pool
+from pyon.datastore.representation import IonSerializerDictionaryRepresentation
+
+class Repository(object):
+
+    def __init__(self, pools, representation=None):
+        self._pool = pools
+        if representation:
+            self._representation = representation
+        else:
+            self._id_factory = SaltedTimeIDFactory()
+            self._representation = IonSerializerDictionaryRepresentation(id_factory=self._id_factory)
+
+    def close(self):
+        for pool in self._pool.values():
+            pool.close(op=self._close_connection)
+
+    def _close_connection(self, connection):
+        connection.close()
+
+    #############################
+
+    def _validate_object(self, arg):
+        ''' check that arg is IonObject or list of IonObjects '''
+        if isinstance(arg, IonObjectBase):
+            return
+        if isinstance(arg, list) and len(arg) and all([isinstance(o, IonObjectBase) for o in arg]):
+            return
+        raise BadRequest('invalid repository entry type ' + arg.__class__.__name__ + ': ' + repr(arg))
+
+    def _validate_object_or_id(self, arg):
+        ''' collection of IDs is valid, otherwise check for valid IonObject(s) '''
+        if isinstance(arg, str):
+            return
+        if isinstance(arg, list) and len(arg) and all([isinstance(id, str) for id in arg]):
+            return
+        self._validate_object(arg)
+
+    def _is_id(self, arg):
+        return isinstance(arg, str) or (isinstance(arg, list) and isinstance(arg[0], str))
+    
+    #############################
+    #
+    # CRUD operations delegate to datastore
+    # all use _perform for consistency:
+    # - check argument for allowed types argect, id, list of objects or list of ids
+    # - get pooled datastore instance
+    # - perform operation, notify of any non-application exceptions
+    # - return connection to pool
+
+    def insert(self, store, arg, _connection=None, **kw):
+        """ insert one or more IonObjects into the DB
+            return value is one/list of triples (success, id, exception)
+                   indicating success or failure per insert
+        """
+        if not _connection:
+            self._validate_object(arg)
+            encoded = self._encode(arg, add_id=True)
+            return self._perform(self.insert, store, encoded)
+        return _connection.insert(arg, **kw)
+
+    def update(self, store, arg, _connection=None, **kw):
+        """ update one or more IonObjects
+            return value is one/list of triples (success, id, exception)
+                   indicating success or failure per insert
+        """
+        if not _connection:
+            self._validate_object(arg)
+            return self._perform(self.update, store, self._encode(arg))
+        return _connection.update(arg, **kw)
+
+    def read(self, store, arg, _connection=None, **kw):
+        """ read one or more IonObjects from the DB
+            arg may be IonObject(s) (which will be updated)
+                or if type is provided, id(s)
+            returns one/list of tuples (success, id, IonObject or exception)
+        """
+        if not _connection:
+            self._validate_object_or_id(arg)
+            return self._perform(self.read, store, self._encode_or_id(arg))
+        return self._decode(_connection.read(arg, **kw))
+
+    def delete(self, store, arg, _connection=None, **kw):
+        """ delete one or more objects from the DB
+            arg may be IonObject(s), or if type is provided, id(s)
+            return value is one/list of triples (success, id, exception)
+                   indicating success or failure per insert
+        """
+        if not _connection:
+            self._validate_object_or_id(arg)
+            return self._perform(self.delete, store, self._encode_or_id(arg))
+        return _connection.delete(arg, **kw)
+
+    def _encode_or_id(self, arg):
+        if self._is_id(arg):
+            return arg
+        else:
+            return self._encode(arg)
+            
+    def _encode(self, arg, add_id=False):
+        if isinstance(arg, list):
+            return [ self._encode(o, add_id=add_id) for o in arg ]
+        return self._representation.encode(arg, add_id=add_id)
+
+    def _decode(self, arg):
+        if isinstance(arg, list):
+            return [ self._decode(d) for d in arg ]
+        if isinstance(arg, tuple):
+            return arg[0], arg[1], self._decode(arg[2])
+        if isinstance(arg, Exception):
+            return arg
+        return self._representation.decode(arg)
+    
+    def _perform(self, op, store, *args, **kwargs):
+        """ re-invoke the calling operation with a pooled DB connection """
+        pool = self._pool[store]
+        connection = pool.check_out()
+        if not connection:
+            raise ServerError('failed to get a connection for store: ' + store)
+        try:
+            return op(store, *args, _connection=connection, **kwargs)
+        except IonException:
+            raise
+        except:
+            # should have been rethrown as application exception by store, find and fix these occurrences...
+            log.error('unexpected exception from datastore', exc_info=True)
+            raise
+        finally:
+            pool.check_in(connection)
+
+    #############################
+    #
+    # NOT YET IMPLEMENTED
+
+    def create_association(self, subject=None, predicate=None, arg=None, assoc_type=AT.H2H): pass
+    def delete_association(self, association=''): pass
+
+    def find_objects(self, subject, predicate="", object_type="", id_only=False): pass
+    def find_subjects(self, subject_type="", predicate="", obj="", id_only=False): pass
+    def find_associations(self, subject="", predicate="", obj="", assoc_type=AT.H2H, id_only=True): pass
+    def find_resources(self, restype="", lcstate="", name="", id_only=True): pass
+

--- a/pyon/datastore/representation.py
+++ b/pyon/datastore/representation.py
@@ -1,0 +1,25 @@
+""" abstract and default implementation of of a Representation object
+    that maps IonObjects to or from a DB-specific data structure
+"""
+
+from pyon.core.object import IonObjectSerializer, IonObjectDeserializer
+from pyon.core.bootstrap import get_obj_registry
+
+class Representation(object):
+    def encode(self, obj, **kw):
+        pass
+    def decode(self, obj):
+        pass
+
+class IonSerializerDictionaryRepresentation(Representation):
+    def __init__(self, id_factory):
+        self.encoder = IonObjectSerializer()
+        self.decoder = IonObjectDeserializer(obj_registry=get_obj_registry())
+        self.id_factory = id_factory
+    def encode(self, obj, add_id=False):
+        out = self.encoder.serialize(obj)
+        if add_id and '_id' not in out.keys():
+            out['_id'] = self.id_factory.create_id()
+        return out
+    def decode(self, data):
+        return self.decoder.deserialize(data)

--- a/pyon/datastore/test/test_id_factory.py
+++ b/pyon/datastore/test/test_id_factory.py
@@ -1,0 +1,32 @@
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.datastore.couchdb.id_factory import IDFactory, SaltedTimeIDFactory
+from nose.plugins.attrib import attr
+
+@attr('UNIT', group='datastore')
+class GeneratorTest(IonIntegrationTestCase):
+
+    def test_length(self):
+        subject = SaltedTimeIDFactory()
+        id = subject.create_id()
+        self.assertEqual(10, len(id))
+
+        sub2 = SaltedTimeIDFactory(salt_chars=5)
+        id = sub2.create_id()
+        self.assertEqual(12, len(id))
+
+    def test_increasing(self):
+        subject = SaltedTimeIDFactory()
+        id1 = subject.create_id()
+        for n in xrange(20):
+            id2 = subject.create_id()
+            self.assertTrue(id2>id1, msg='%s v %s'%(id1,id2))
+            id1=id2
+
+    def test_change_salt(self):
+        # use unusually large salt to make it
+        # nearly impossible 2 random salts will be equal
+        subject = SaltedTimeIDFactory(salt_chars=10)
+        id1 = subject.create_id()
+        id2 = subject.replace_duplicate()
+        self.assertTrue(id1[-10:]!=id2[-10:])
+

--- a/pyon/datastore/test/test_id_factory.py
+++ b/pyon/datastore/test/test_id_factory.py
@@ -1,5 +1,5 @@
 from pyon.util.int_test import IonIntegrationTestCase
-from pyon.datastore.couchdb.id_factory import IDFactory, SaltedTimeIDFactory
+from pyon.datastore.id_factory import IDFactory, SaltedTimeIDFactory
 from nose.plugins.attrib import attr
 
 @attr('UNIT', group='datastore')

--- a/pyon/datastore/test/test_pool.py
+++ b/pyon/datastore/test/test_pool.py
@@ -1,0 +1,50 @@
+from pyon.core.bootstrap import IonObject
+from pyon.datastore.pool import Pool
+from pyon.ion.resource import RT
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.datastore.couchdb.id_factory import IDFactory, SaltedTimeIDFactory
+from nose.plugins.attrib import attr
+
+@attr('UNIT', group='datastore')
+class SwimTest(IonIntegrationTestCase):
+
+    _id = 0
+    def _create_object(self,name):
+        self._id += 1
+        return 'thing'+str(self._id)
+
+    def test_check_out(self):
+        subject = Pool('testpool',self._create_object)
+
+        o1 = subject.check_out()
+        o2 = subject.check_out()
+
+        self.assertNotEqual(o1,o2)
+        self.assertTrue(o1 in subject._used)
+        self.assertFalse(o1 in subject._unused)
+
+        subject.check_in(o1)
+        self.assertFalse(o1 in subject._used)
+        self.assertTrue(o1 in subject._unused)
+
+        o3 = subject.check_out()
+        self.assertEqual(o1,o3)
+
+    def test_limit(self):
+        subject = Pool('testpool',self._create_object, max_connections=3)
+
+        # check out max
+        for n in xrange(3):
+            o = subject.check_out()
+            self.assertTrue(o is not None)
+
+        # should fail if try for one more
+        try:
+            o = subject.check_out()
+            self.fail('should not checkout more than max')
+        except:
+            pass
+
+        # return one, now can check out more
+        subject.check_in(o)
+        o2 = subject.check_out()

--- a/pyon/datastore/test/test_pool.py
+++ b/pyon/datastore/test/test_pool.py
@@ -1,8 +1,5 @@
-from pyon.core.bootstrap import IonObject
 from pyon.datastore.pool import Pool
-from pyon.ion.resource import RT
 from pyon.util.int_test import IonIntegrationTestCase
-from pyon.datastore.couchdb.id_factory import IDFactory, SaltedTimeIDFactory
 from nose.plugins.attrib import attr
 
 @attr('UNIT', group='datastore')

--- a/pyon/datastore/test/test_repository_crud.py
+++ b/pyon/datastore/test/test_repository_crud.py
@@ -1,0 +1,198 @@
+from pyon.core.bootstrap import IonObject
+from pyon.datastore.couchdb.couch_pool import CouchDBPoolDict
+from pyon.datastore.id_factory import SaltedTimeIDFactory
+from pyon.datastore.repository import Repository
+from pyon.ion.resource import RT
+from pyon.util.int_test import IonIntegrationTestCase
+from nose.plugins.attrib import attr
+
+@attr('INT', group='datastore')
+class TestCouchStore(IonIntegrationTestCase):
+    def setUp(self):
+        id_factory = SaltedTimeIDFactory()
+        self.pools = CouchDBPoolDict(prefix='testcouchstore'+id_factory.create_id().lower(), can_create=True, must_create=True)
+        self.repo = Repository(self.pools)
+
+    def tearDown(self):
+        for pool in self.pools.values():
+            try:
+                db = pool.check_out()
+                db.drop()
+            except:
+                pass
+
+    def test_crud_obj(self):
+        """ crud operations using objects where possible """
+        obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        success,id,ex = self.repo.insert('sample', obj)
+        self.assertTrue(success)
+        self.assertFalse('_id' in obj.__dict__.keys())
+        success,id,obj2 = self.repo.read('sample', id)
+        self.assertTrue(success)
+        for key in ['name', 'description', 'serial_number']:
+            self.assertEqual(obj.__dict__[key],obj2.__dict__[key], msg='objects do not have the same '+key)
+
+        obj2.name='new name'
+        success,id,ex = self.repo.update('sample', obj2)
+        self.assertTrue(success)
+        success,id,obj3 = self.repo.read('sample', obj2)
+        self.assertTrue(success)
+        for key in ['description', 'serial_number']:
+            self.assertEqual(obj.__dict__[key],obj3.__dict__[key], msg='objects do not have the same '+key)
+        for key in ['_id', 'name', 'description', 'serial_number']:
+            self.assertEqual(obj2.__dict__[key],obj3.__dict__[key], msg='objects do not have the same '+key)
+
+        success,id,ex = self.repo.delete('sample', obj3)
+        self.assertTrue(success)
+
+
+    def test_crud_ids(self):
+        """ crud operations using objects where possible """
+        obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        success,id,ex = self.repo.insert('sample', obj)
+        self.assertTrue(success)
+        self.assertFalse('_id' in obj.__dict__.keys())
+        success,id,obj2 = self.repo.read('sample', id)
+        self.assertTrue(success)
+        for key in ['name', 'description', 'serial_number']:
+            self.assertEqual(obj.__dict__[key],obj2.__dict__[key], msg='objects do not have the same '+key)
+
+        obj2.name='new name'
+        success,id,ex = self.repo.update('sample', obj2)
+        self.assertTrue(success)
+        success,id,obj3 = self.repo.read('sample', id)
+        self.assertTrue(success)
+        for key in ['description', 'serial_number']:
+            self.assertEqual(obj.__dict__[key],obj3.__dict__[key], msg='objects do not have the same '+key)
+        for key in ['_id', 'name', 'description', 'serial_number']:
+            self.assertEqual(obj2.__dict__[key],obj3.__dict__[key], msg='objects do not have the same '+key)
+
+        success,id,ex = self.repo.delete('sample', id)
+        self.assertTrue(success)
+
+    def test_crud_list_obj(self):
+        """ crud operations using objects where possible """
+        obj1 = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        obj2 = IonObject(RT.Observatory, name='mount spaghetti', description='covered with snow')
+        objs = [obj1,obj2]
+        tuples = self.repo.insert('sample', objs)
+
+        for t in tuples:
+            self.assertTrue(t[0])
+            self.assertTrue(t[1] is not None)
+
+        ids = [ tuples[0][1], tuples[1][1], 'howdy' ]
+        tuples = self.repo.read('sample', ids)
+        self.assertTrue(tuples[0][0])
+        self.assertTrue(tuples[1][0])
+        self.assertFalse(tuples[2][0])
+
+        obj3 = tuples[0][2]
+        obj4 = tuples[1][2]
+        obj3.name = 'no longer SBE'
+        obj4.description = 'no more snow'
+        obj1._id = 'abc123'
+        objs = [ obj3, obj4, obj1 ]
+        tuples = self.repo.update('sample', objs)
+        self.assertTrue(tuples[0][0])
+        self.assertTrue(tuples[1][0])
+        self.assertFalse(tuples[2][0])
+
+        tuples = self.repo.read('sample', objs)
+        self.assertTrue(tuples[0][0])
+        self.assertTrue(tuples[1][0])
+        self.assertFalse(tuples[2][0])
+        obj5 = tuples[0][2]
+        obj6 = tuples[1][2]
+        for key in ['_id', 'name', 'description', 'serial_number']:
+            self.assertEqual(obj3.__dict__[key],obj5.__dict__[key], msg='objects do not have the same '+key)
+
+        objs = [ obj4, obj5 ]  # 4 has obsolete _rev
+        tuples = self.repo.delete('sample', objs)
+        self.assertFalse(tuples[0][0])
+        self.assertTrue(tuples[1][0], msg='failed: '+str(tuples[1][2]) +'\nobj: ' + repr(obj5.__dict__))
+
+        objs = [ obj5, obj6 ]  # 5 is already deleted
+        tuples = self.repo.delete('sample', objs)
+        self.assertFalse(tuples[0][0])
+        self.assertTrue(tuples[1][0], msg='failed: '+str(tuples[1][2]) +'\nobj: ' + repr(obj5.__dict__))
+
+
+    def test_crud_list_ids(self):
+        """ crud operations using objects where possible """
+        obj1 = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        obj2 = IonObject(RT.Observatory, name='mount spaghetti', description='covered with snow')
+        objs = [obj1,obj2]
+        tuples = self.repo.insert('sample', objs)
+
+        for t in tuples:
+            self.assertTrue(t[0])
+            self.assertTrue(t[1] is not None)
+
+        ids = [ tuples[0][1], tuples[1][1], 'howdy' ]
+        tuples = self.repo.read('sample', ids)
+        self.assertTrue(tuples[0][0])
+        self.assertTrue(tuples[1][0])
+        self.assertFalse(tuples[2][0])
+
+        obj3 = tuples[0][2]
+        obj4 = tuples[1][2]
+        obj3.name = 'no longer SBE'
+        obj4.description = 'no more snow'
+        obj1._id = 'abc123'
+        objs = [ obj3, obj4, obj1 ]
+        tuples = self.repo.update('sample', objs)
+        self.assertTrue(tuples[0][0])
+        self.assertTrue(tuples[1][0])
+        self.assertFalse(tuples[2][0])
+
+        tuples = self.repo.read('sample', ids)
+        self.assertTrue(tuples[0][0])
+        self.assertTrue(tuples[1][0])
+        self.assertFalse(tuples[2][0])
+        obj5 = tuples[0][2]
+        obj6 = tuples[1][2]
+        for key in ['_id', 'name', 'description', 'serial_number']:
+            self.assertEqual(obj3.__dict__[key],obj5.__dict__[key], msg='objects do not have the same '+key)
+
+        ids = [ 'badID', obj5._id ]  # 4 has obsolete _rev
+        tuples = self.repo.delete('sample', ids)
+        self.assertFalse(tuples[0][0])
+        self.assertTrue(tuples[1][0], msg='failed: '+str(tuples[1][2]) +'\nobj: ' + repr(obj5.__dict__))
+
+        objs = [ obj5, obj6 ]  # 5 is already deleted
+        tuples = self.repo.delete('sample', [ o._id for o in objs ])
+#        self.assertFalse(tuples[0][0]) -- couch will allow second delete operation!
+        self.assertTrue(tuples[1][0], msg='failed: '+str(tuples[1][2]) +'\nobj: ' + repr(obj5.__dict__))
+
+    def test_expected_errors(self):
+        obj1 = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345")
+
+        try:
+            self.repo.insert('bad name', obj1)
+            self.fail('should fail')
+        except:
+            pass
+
+        try:
+            self.repo.insert('sample', None)
+            self.fail('should fail')
+        except:
+            pass
+
+        try:
+            self.repo.insert('sample', "not ion obj")
+            self.fail('should fail')
+        except:
+            pass
+
+
+        success,id,ex = self.repo.insert('sample', obj1)
+        _,__,obj2 = self.repo.read('sample', id)
+        try:
+            success,_,__ = self.repo.insert('sample', obj2)
+            self.fail('should not succeed')
+        except:
+            pass
+        self.assertFalse(success)
+

--- a/pyon/datastore/test/test_repository_crud.py
+++ b/pyon/datastore/test/test_repository_crud.py
@@ -22,7 +22,7 @@ class TestCouchStore(IonIntegrationTestCase):
                 pass
 
     def test_crud_obj(self):
-        """ crud operations using objects where possible """
+        """ crud operations using an object where possible """
         obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
         success,id,ex = self.repo.insert('sample', obj)
         self.assertTrue(success)
@@ -47,7 +47,7 @@ class TestCouchStore(IonIntegrationTestCase):
 
 
     def test_crud_ids(self):
-        """ crud operations using objects where possible """
+        """ crud operations using an id where possible """
         obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
         success,id,ex = self.repo.insert('sample', obj)
         self.assertTrue(success)
@@ -71,7 +71,7 @@ class TestCouchStore(IonIntegrationTestCase):
         self.assertTrue(success)
 
     def test_crud_list_obj(self):
-        """ crud operations using objects where possible """
+        """ crud batch operations using lists of objects where possible """
         obj1 = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
         obj2 = IonObject(RT.Observatory, name='mount spaghetti', description='covered with snow')
         objs = [obj1,obj2]
@@ -119,7 +119,7 @@ class TestCouchStore(IonIntegrationTestCase):
 
 
     def test_crud_list_ids(self):
-        """ crud operations using objects where possible """
+        """ crud batch operations using lists of ids where possible """
         obj1 = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
         obj2 = IonObject(RT.Observatory, name='mount spaghetti', description='covered with snow')
         objs = [obj1,obj2]
@@ -165,15 +165,18 @@ class TestCouchStore(IonIntegrationTestCase):
 #        self.assertFalse(tuples[0][0]) -- couch will allow second delete operation!
         self.assertTrue(tuples[1][0], msg='failed: '+str(tuples[1][2]) +'\nobj: ' + repr(obj5.__dict__))
 
-    def test_expected_errors(self):
+    def test_expected_exceptions(self):
+        """ test uses that are expected to throw exceptions (and probably need code fixes) """
         obj1 = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345")
 
+        # invalid name for repository
         try:
             self.repo.insert('bad name', obj1)
             self.fail('should fail')
         except:
             pass
 
+        # invalid argument types
         try:
             self.repo.insert('sample', None)
             self.fail('should fail')
@@ -186,13 +189,20 @@ class TestCouchStore(IonIntegrationTestCase):
         except:
             pass
 
-
-        success,id,ex = self.repo.insert('sample', obj1)
+        # cannot reinsert with same id
+        _,id,__ = self.repo.insert('sample', obj1)
         _,__,obj2 = self.repo.read('sample', id)
         try:
             success,_,__ = self.repo.insert('sample', obj2)
             self.fail('should not succeed')
         except:
             pass
-        self.assertFalse(success)
+
+        # cannot insert with _rev
+        obj1._rev = obj2._rev
+        try:
+            success,_,__ = self.repo.insert('sample', obj1)
+            self.fail('should not succeed')
+        except:
+            pass
 

--- a/pyon/datastore/test/test_representation.py
+++ b/pyon/datastore/test/test_representation.py
@@ -1,0 +1,43 @@
+from pyon.core.bootstrap import IonObject
+from pyon.datastore.representation import IonSerializerDictionaryRepresentation
+from pyon.ion.resource import RT
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.datastore.couchdb.id_factory import IDFactory, SaltedTimeIDFactory
+from nose.plugins.attrib import attr
+
+@attr('UNIT', group='datastore')
+class RepresentationTest(IonIntegrationTestCase):
+
+    def setUp(self):
+        self.subject = IonSerializerDictionaryRepresentation(id_factory=SaltedTimeIDFactory())
+
+    def test_encode_decode(self):
+        obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        d = self.subject.encode(obj)
+        print 'keys: ' + repr(d)
+        self.assertFalse('_id' in d.keys())
+        new_obj = self.subject.decode(d)
+        self.assertEqual(obj, new_obj)
+        d2 = self.subject.encode(new_obj, add_id=True)
+        self.assertTrue('_id' in d2.keys(), msg=repr(d2.keys()))
+
+        # retains key once added
+        d3 = self.subject.encode(self.subject.decode(d2))
+        self.assertTrue('_id' in d3.keys())
+
+    def test_fails(self):
+        d = {}
+        try:
+            self.subject.decode(d)
+            self.fail('should not have worked')
+        except:
+            pass
+
+        obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        d2 = self.subject.encode(obj)
+        d2['more']='stuff'
+        try:
+            self.subject.decode(d2)
+            self.fail('should not be able to decode')
+        except:
+            pass

--- a/pyon/datastore/test/test_representation.py
+++ b/pyon/datastore/test/test_representation.py
@@ -2,7 +2,7 @@ from pyon.core.bootstrap import IonObject
 from pyon.datastore.representation import IonSerializerDictionaryRepresentation
 from pyon.ion.resource import RT
 from pyon.util.int_test import IonIntegrationTestCase
-from pyon.datastore.couchdb.id_factory import IDFactory, SaltedTimeIDFactory
+from pyon.datastore.id_factory import SaltedTimeIDFactory
 from nose.plugins.attrib import attr
 
 @attr('UNIT', group='datastore')


### PR DESCRIPTION
initial classes for splitting couchdb_datastore into IonObject-specific repository.py and dict-only db-specific couch_store.py.  also includes connection pooling and shorter and sequential ID generation.
