### PR TITLE
Luke: adds the ability to combine granules

### DIFF
--- a/pyon/ion/granule/__init__.py
+++ b/pyon/ion/granule/__init__.py
@@ -1,1 +1,5 @@
 __author__ = 'timgiguere'
+
+from pyon.ion.granule.granule import build_granule, combine_granules
+from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from pyon.ion.granule.taxonomy import TaxyTool

--- a/pyon/ion/granule/granule.py
+++ b/pyon/ion/granule/granule.py
@@ -10,6 +10,12 @@
 
 
 from interface.objects import Granule
+from pyon.core.exception import BadRequest
+from pyon.util.arg_check import validate_is_instance
+from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from pyon.ion.granule.taxonomy import TaxyTool
+
+import numpy as np
 
 
 def build_granule(data_producer_id, taxonomy, record_dictionary):
@@ -25,5 +31,28 @@ def build_granule(data_producer_id, taxonomy, record_dictionary):
 
     #@todo If the taxonomy has an id_ and rev_ send only that.
     return Granule(data_producer_id=data_producer_id, record_dictionary=record_dictionary._rd, taxonomy=taxonomy._t)
+
+def combine_granules(granule_a, granule_b):
+    """
+    This is a method that combines granules in a very naive manner
+    """
+    validate_is_instance(granule_a,Granule, 'granule_a is not a proper Granule')
+    validate_is_instance(granule_b,Granule, 'granule_b is not a proper Granule')
+
+    tt_a = TaxyTool.load_from_granule(granule_a)
+    tt_b = TaxyTool.load_from_granule(granule_b)
+
+    if tt_a != tt_b:
+        raise BadRequest('Can\'t combine the two granules, they do not have the same taxonomy.')
+
+    rdt_new = RecordDictionaryTool(tt_a)
+    rdt_a = RecordDictionaryTool.load_from_granule(granule_a)
+    rdt_b = RecordDictionaryTool.load_from_granule(granule_b)
+
+
+    for k in rdt_a.iterkeys():
+        rdt_new[k] = np.append(rdt_a[k], rdt_b[k])
+    return build_granule(granule_a.data_producer_id, tt_a, rdt_new)
+
 
 

--- a/pyon/ion/granule/taxonomy.py
+++ b/pyon/ion/granule/taxonomy.py
@@ -260,4 +260,7 @@ class TaxyTool(object):
 
         return False
 
+    def __ne__(self, other):
+        return not self == other
+
 

--- a/pyon/ion/granule/test/test_granule.py
+++ b/pyon/ion/granule/test/test_granule.py
@@ -13,7 +13,7 @@ import unittest
 import numpy
 from nose.plugins.attrib import attr
 from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from pyon.ion.granule.granule import build_granule, combine_granules
 from pyon.ion.granule.record_dictionary import RecordDictionaryTool
 
 
@@ -76,3 +76,22 @@ class GranuleTestCase(unittest.TestCase):
             else:
                 self.assertEquals(v._rd, rdt[k]._rd)
 
+    def test_combine_granule(self):
+        tt = TaxyTool()
+        tt.add_taxonomy_set('a')
+
+        rdt = RecordDictionaryTool(tt)
+        rdt['a'] = numpy.array([1,2,3])
+
+        granule1 = build_granule('test',tt,rdt)
+
+        rdt = RecordDictionaryTool(tt)
+        rdt['a'] = numpy.array([4,5,6])
+        
+        granule2 = build_granule('test',tt,rdt)
+
+        granule3 = combine_granules(granule1,granule2)
+
+        rdt = RecordDictionaryTool.load_from_granule(granule3)
+
+        self.assertTrue(numpy.allclose(rdt['a'],numpy.array([1,2,3,4,5,6])))


### PR DESCRIPTION
- Primitive combination of granules
- Moves the granule classes into the init file for easier imports

You may now import the granule wrappers from `pyon.ion.granule` directly:

```
from pyon.ion.granule import RecordDictionaryTool, TaxyTool, build_granule, combine_granules
```
