### PR TITLE
Luke: Provides utilities for comparing primitive XML documents.

### DIFF
--- a/pyon/ion/streamdef.py
+++ b/pyon/ion/streamdef.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+'''
+@author Luke Campbell <LCampbell@ASAScience.com>
+@file pyon/ion/streamdef.py
+@date Thu Jul  5 14:40:49 EDT 2012
+@description Utility for managing stream definitions
+'''
+
+from lxml import etree
+
+
+class StreamDef(object):
+    def __init__(self, xml_string):
+        self._element = etree.fromstring(xml_string)
+
+    def xpath(self, path):
+        return self._element.xpath(path)
+
+

--- a/pyon/ion/streamdef.py
+++ b/pyon/ion/streamdef.py
@@ -16,4 +16,22 @@ class StreamDef(object):
     def xpath(self, path):
         return self._element.xpath(path)
 
+    def __eq__(self, sd2):
+        return str(self) == str(sd2)
+
+    def __ne__(self, sd2):
+        return not self == sd2
+
+    def __repr__(self):
+        retval = str(self)
+        if len(retval) >= 14:
+            retval = retval[:14] + '...'
+        return '<%s "%s" at 0x%x>' % (self.__class__.__name__, retval, id(self))
+
+    def __str__(self):
+        return etree.tostring(self._element)
+
+    def __contains__(self, xpath):
+        return bool(self.xpath(xpath))
+
 

--- a/pyon/ion/test/test_streamdef.py
+++ b/pyon/ion/test/test_streamdef.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+'''
+@author Luke Campbell <LCampbell@ASAScience.com>
+@file pyon/ion/streamdef.py
+@date Thu Jul  5 14:40:49 EDT 2012
+@description Utility for managing stream definitions
+'''
+
+from pyon.util.unit_test import PyonTestCase
+from pyon.ion.streamdef import StreamDef
+from nose.plugins.attrib import attr
+
+xml_def1 = '''
+<stream-definition>
+  <conductivity />
+  <temperature />
+  <depth />
+</stream-definition>'''
+xml_def2 = '''
+<stream-definition>
+  <temperature />
+</stream-definition>'''
+
+
+
+
+
+@attr('UNIT')
+class StreamDefUnitTest(PyonTestCase):
+    def test_stream_def_compare(self):
+        stream_def1 = StreamDef(xml_def1)
+        stream_def2 = StreamDef(xml_def2)
+
+        stream_def3 = StreamDef(xml_def1)
+
+        self.assertTrue(stream_def1 == stream_def3)
+        self.assertFalse(stream_def1 == stream_def2)
+        self.assertTrue(stream_def1 != stream_def2)
+
+        self.assertTrue('/stream-definition/temperature' in stream_def1)
+        self.assertTrue('/stream-definition/temperature' in stream_def2)
+        self.assertTrue('/stream-definition/conductivity' in stream_def1)
+        self.assertFalse('/stream-definition/conductivity' in stream_def2)
+
+


### PR DESCRIPTION
This set of utilities is intended for addressing the need of a utility for comparing and querying a stream definition.

**The intention is for this to be immutable. There is no intended supported for DOM manipulation or element injection.**

Example:
Given the following XML Document

```
<stream-definition>
  <range>
    <temperature taxonomy='taxid' />
    <conductivity taxonomy='taxid' />
    <depth taxonomy='taxid' />
  </range>
  <domain>
    <time taxonomy='taxid' />
  </domain>
</stream-definition>
```

You may perform the following on it

```
xml_doc # With the above as it's contents
stream_def_xml = StreamDef(xml_doc)
if '/stream-definition/range/depth' in stream_def_xml:
  pass
stream_def_xml2 = StreamDef(xml_doc)
if stream_def_xml2 == stream_def_xml:
  pass
```
