### PR TITLE
fix bug 'old_state referenced before assignment' when retiring a resource

### DIFF
--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -126,7 +126,7 @@ class ResourceRegistry(object):
         """
         This is the official "delete" for resource objects: they are set to RETIRED lcstate
         """
-        self.set_lifecycle_state(resource_id, "RETIRED")
+        self.set_lifecycle_state(resource_id, LCS.RETIRED)
 
     def delete(self, object_id='', del_associations=False):
         res_obj = self.read(object_id)
@@ -136,7 +136,7 @@ class ResourceRegistry(object):
         if not del_associations:
             self._delete_owners(object_id)
 
-        res_obj.lcstate = 'RETIRED'
+        res_obj.lcstate = LCS.RETIRED
         self.rr_store.update(res_obj)
         res = self.rr_store.delete(object_id, del_associations=del_associations)
 
@@ -183,14 +183,14 @@ class ResourceRegistry(object):
             raise BadRequest("Unknown life-cycle state %s" % target_lcstate)
 
         res_obj = self.read(resource_id)
-        if target_lcstate != "RETIRED":
+        old_state = res_obj.lcstate
+        if target_lcstate != LCS.RETIRED:
             restype = res_obj._get_type()
             restype_workflow = get_restype_lcsm(restype)
             if not restype_workflow:
                 raise BadRequest("Resource id=%s type=%s has no lifecycle" % (resource_id, restype))
 
             # Check that target state is allowed
-            old_state = res_obj.lcstate
             if not target_lcstate in restype_workflow.get_successors(res_obj.lcstate).values():
                 raise BadRequest("Target state %s not reachable for resource in state %s" % (target_lcstate, res_obj.lcstate))
 


### PR DESCRIPTION
 use constant value for LCS assignment: LCS.RETIRED instead of "RETIRED"

also, fix this bug:

pyon.core.thread: ERROR: Child failed with an exception: ("local variable 'old_state' referenced before assignment", <pyon.core.thread.PyonThreadTraceback object at 0x105cfd6d0>)
IonProcessThread _control_flow caught an exception (call: <bound method ResourceRegistryService.retire of <ion.services.coi.resource_registry_service.ResourceRegistryService object at 0x105c5c350>>, _args (), *_kwargs {'resource_id': 'd6b0e29436e04580b7754e27660f0e36'}, context {'conv-seq': 1, 'sender': 'silverlining_local_48134.24', 'protocol': 'rpc', 'language': 'ion-r2', 'sender-name': 'observatory_management', 'encoding': 'msgpack', 'reply-by': 'todo', 'sender-service': 'ion_test_6cd505,observatory_management', 'ts': '1342810620393', 'routing_key': 'resource_registry', 'receiver': 'ion_test_6cd505,resource_registry', 'format': 'resource_registry_retire_in', 'reply-to': 'ion_test_6cd505,amq.gen-K9vjs3k4xS0lBYV7JWDRNw==', 'conv-id': 'silverlining_local_48134-217', 'op': 'retire', 'performative': 'request', 'sender-type': 'service'})
True traceback captured by IonProcessThread' _control_flow:

Traceback (most recent call last):
  File "/Users/iankatz/.virtualenvs/artoo/sdtkiai/coi-services/eggs/pyon-0.1.4-py2.7.egg/pyon/ion/process.py", line 131, in _control_flow
    res = call(_callargs, *_callkwargs)
  File "/Users/iankatz/.virtualenvs/artoo/sdtkiai/coi-services/ion/services/coi/resource_registry_service.py", line 44, in retire
    return self.resource_registry.retire(resource_id=resource_id)
  File "/Users/iankatz/.virtualenvs/artoo/sdtkiai/coi-services/eggs/pyon-0.1.4-py2.7.egg/pyon/ion/resregistry.py", line 129, in retire
    self.set_lifecycle_state(resource_id, "RETIRED")
  File "/Users/iankatz/.virtualenvs/artoo/sdtkiai/coi-services/eggs/pyon-0.1.4-py2.7.egg/pyon/ion/resregistry.py", line 205, in set_lifecycle_state
    old_state=old_state, new_state=target_lcstate)
UnboundLocalError: local variable 'old_state' referenced before assignment
