### PR TITLE
New transforms

### DIFF
--- a/pyon/ion/transforma.py
+++ b/pyon/ion/transforma.py
@@ -6,11 +6,7 @@
 @description: New Implementation for TransformBase class
 '''
 
-from gevent import spawn
-
-from pyon.core.bootstrap import get_sys_name
 from pyon.ion.process import SimpleProcess
-from pyon.net.endpoint import Subscriber, Publisher
 from pyon.event.event import EventSubscriber, EventPublisher
 
 from pyon.util.log import log
@@ -31,7 +27,6 @@ class TransformStreamListener(TransformStreamProcess):
     def on_start(self):
         self.queue_name = self.CFG.get_safe('process.queue_name',self.id)
 
-        # @TODO: queue_name is really exchange_name, rename
         self.subscriber = SimpleStreamSubscriber.new_subscriber(self.container, self.queue_name, self.recv_packet)
         self.subscriber.start()
 
@@ -46,7 +41,7 @@ class TransformStreamPublisher(TransformStreamProcess):
     def on_start(self):
         self.exchange_point = self.CFG.get_safe('process.exchange_point', '')
 
-        self.publisher = SimpleStreamPublisher.new_publisher(self.container,self.exchange_point,'')
+        self.publisher = SimpleStreamPublisher.new_publisher(self.container, self.exchange_point,'')
 
     def publish(self, msg, to_name):
         raise NotImplementedError('Method publish not implemented')
@@ -87,7 +82,6 @@ class TransformDatasetProcess(TransformBase):
 class TransformDataProcess(TransformStreamListener, TransformStreamPublisher):
 
     def on_start(self):
-        log.warn('TransformDataProcess.on_start()')
         TransformStreamListener.on_start(self)
         TransformStreamPublisher.on_start(self)
 

--- a/pyon/ion/transforma.py
+++ b/pyon/ion/transforma.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+'''
+@author: Tim Giguere <tgiguere@asascience.com>
+@file: pyon/ion/transforma.py
+@description: New Implementation for TransformBase class
+'''
+
+from gevent import spawn
+
+from pyon.core.bootstrap import get_sys_name
+from pyon.ion.process import SimpleProcess
+from pyon.net.endpoint import Subscriber, Publisher
+from pyon.event.event import EventSubscriber, EventPublisher
+
+from pyon.util.log import log
+
+class TransformBase(SimpleProcess):
+
+    def on_start(self):
+        super(TransformBase,self).on_start()
+
+class TransformStreamProcess(TransformBase):
+    pass
+
+class TransformEventProcess(TransformBase):
+    pass
+
+class TransformStreamListener(TransformStreamProcess):
+
+    def on_start(self):
+        self.queue_name = self.CFG.get_safe('process.queue_name','')
+
+        # @TODO: queue_name is really exchange_name, rename
+        xn = self.container.ex_manager.create_xn_queue(self.queue_name)
+
+        self.subscriber = Subscriber(name=xn, callback=self.recv_packet)
+        self.greenlet = spawn(self.subscriber.listen)
+
+        ## Assign a list of streams available
+        #self.streams = self.CFG.get_safe('process.subscriber_streams',[])
+        #log.warn('TransformStreamListener.on_start()')
+        #self.subscribers = []
+        #self.greenlets = []
+        #for stream in self.streams:
+        #    subscriber = Subscriber(name=stream, callback=self.recv_packet)
+        #    self.subscribers.append(subscriber)
+        #    self.greenlets.append(spawn(subscriber.listen))
+
+    def recv_packet(self, msg, headers):
+        raise NotImplementedError('Method recv_packet not implemented')
+
+    def on_quit(self):
+#        for subscriber in self.subscribers:
+#            subscriber.close()
+#
+#        for greenlet in self.greenlets:
+#            greenlet.join(timeout=10)
+        self.subscriber.close()
+        self.greenlet.join(timeout=10)
+
+class TransformStreamPublisher(TransformStreamProcess):
+
+    def on_start(self):
+        self.exchange_point = self.CFG.get_safe('process.exchange_point', '')
+
+        xp = self.container.ex_manager.create_xp(self.exchange_point)
+
+        self.publisher = Publisher()
+#        # Assign a list of streams available
+#        self.streams = self.CFG.get_safe('process.publish_streams',[])
+#        log.warn('TransformStreamPublisher.on_start()')
+#        self.publishers = []
+#        #self.greenlets = []
+#        for stream in self.streams:
+#            publisher = Publisher(name=(get_sys_name(), stream), node=self.container.node)
+#            self.publishers.append(publisher)
+#            #self.greenlets.append(spawn(publisher.publish))
+
+    def publish(self, msg, to_name):
+        raise NotImplementedError('Method publish not implemented')
+
+    def on_quit(self):
+        self.publisher.close()
+#        for publisher in self.publishers:
+#            publisher.close()
+
+        #for greenlet in self.greenlets:
+        #    greenlet.join(timeout=10)
+
+class TransformEventListener(TransformEventProcess):
+
+    def on_start(self):
+        event_type = self.CFG.get_safe('process.event_type', '')
+
+        self.listener = EventSubscriber(event_type=event_type, callback=self.process_event)
+        self.listener.start()
+
+    def process_event(self, msg, headers):
+        raise NotImplementedError('Method process_event not implemented')
+
+    def on_quit(self):
+        self.listener.stop()
+
+class TransformEventPublisher(TransformEventProcess):
+
+    def on_start(self):
+        event_type = self.CFG.get_safe('process.event_type', '')
+
+        self.publisher = EventPublisher(event_type=event_type)
+
+    def publish_event(self, *args, **kwargs):
+        raise NotImplementedError('Method publish_event not implemented')
+
+    def on_quit(self):
+        self.publisher.close()
+
+class TransformDatasetProcess(TransformBase):
+    pass
+
+class TransformDataProcess(TransformStreamListener, TransformStreamPublisher):
+
+    def on_start(self):
+        log.warn('TransformDataProcess.on_start()')
+        TransformStreamListener.on_start(self)
+        TransformStreamPublisher.on_start(self)
+
+class TransformAlgorithm(object):
+
+    @staticmethod
+    def execute(*args, **kwargs):
+        raise NotImplementedError('Method execute not implemented')#!/usr/bin/env python

--- a/pyon/ion/transforma.py
+++ b/pyon/ion/transforma.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+'''
+@author: Tim Giguere <tgiguere@asascience.com>
+@file: pyon/ion/transforma.py
+@description: New Implementation for TransformBase class
+'''
+
+from gevent import spawn
+
+from pyon.core.bootstrap import get_sys_name
+from pyon.ion.process import SimpleProcess
+from pyon.net.endpoint import Subscriber, Publisher
+from pyon.event.event import EventSubscriber, EventPublisher
+
+from pyon.util.log import log
+
+class TransformBase(SimpleProcess):
+    """
+
+    """
+
+    pass
+
+class TransformStreamProcess(TransformBase):
+    pass
+
+class TransformEventProcess(TransformBase):
+    pass
+
+class TransformStreamListener(TransformStreamProcess):
+
+    def on_start(self):
+        # Assign a list of streams available
+        self.streams = self.CFG.get_safe('process.subscriber_streams',[])
+
+        self.subscribers = []
+        self.greenlets = []
+        for stream in self.streams:
+            subscriber = Subscriber(name=(get_sys_name(), stream), callback=self.recv_packet)
+            self.subscribers.append(subscriber)
+            self.greenlets.append(spawn(subscriber.listen))
+
+    def recv_packet(self, packet, stream_id):
+        raise NotImplementedError('Method recv_packet not implemented')
+
+    def on_quit(self):
+        for subscriber in self.subscribers:
+            subscriber.close()
+
+class TransformStreamPublisher(TransformStreamProcess):
+
+    def on_start(self):
+        # Assign a list of streams available
+        self.streams = self.CFG.get_safe('process.publish_streams',[])
+
+        self.publishers = []
+        self.greenlets = []
+        for stream in self.streams:
+            publisher = Publisher(name=(get_sys_name(), stream), callback=self.publish)
+            self.publishers.append(publisher)
+            self.greenlets.append(spawn(publisher.publish))
+
+    def publish(self, msg, headers):
+        raise NotImplementedError('Method publish not implemented')
+
+    def on_quit(self):
+        for publisher in self.publishers:
+            publisher.close()
+
+class TransformEventListener(TransformEventProcess):
+
+    def on_start(self):
+        event_type = self.CFG.get_safe('process.event_type', '')
+
+        self.greenlets = []
+
+        self.listener = EventSubscriber(event_type=event_type, callback=self.process_event)
+        self.greenlets.append(spawn(self.listener.listen))
+
+    def process_event(self):
+        raise NotImplementedError('Method process_event not implemented')
+
+    def on_quit(self):
+        self.listener.close()
+
+class TransformEventPublisher(TransformEventProcess):
+
+    def on_start(self):
+        event_type = self.CFG.get_safe('process.event_type', '')
+
+        self.publisher = EventPublisher(event_type=event_type)
+
+    def publish_event(self, origin, sub_type, description):
+        self.publisher.publish_event(origin=origin, sub_type=sub_type, description=description)
+
+    def on_quit(self):
+        self.publisher.close()
+
+class TransformDatasetProcess(TransformBase):
+    pass
+
+class TransformDataProcess(TransformStreamListener, TransformStreamPublisher):
+    pass


### PR DESCRIPTION
pyon.ion.transforma contains the new Transform model. See https://confluence.oceanobservatories.org/display/CIDev/R2+Transformation for a diagram representing the new model. Please start moving your transforms over to this model, as TransformManagementService is going to be removed. Simple CTD examples are provided in coi-services.ion.processes.data.transforms.ctd (filenames that end with '_a').
