### PR TITLE
Luke: Adds extended capabilities to time representation

### DIFF
--- a/pyon/util/ion_time.py
+++ b/pyon/util/ion_time.py
@@ -7,64 +7,170 @@
 '''
 import numpy as np
 import time
+import datetime
+import struct
+import numbers
 
 class IonTime(object):
     '''
     Utility wrapper for handling time in ntpv4
+    Everything is in ZULU Time
     '''
     FRAC = np.float32(4294967296.)
     JAN_1970 = np.uint32(2208988800)
+    EPOCH = datetime.datetime(1900,1,1)
+
+    ntpv4_timestamp = '! 2I'
+    ntpv4_date      = '! 2I Q'
 
     def __init__(self,date=None): 
         '''Can be initialized with a standard unix time stamp'''
         if date is None:
             date = time.time()
-        self.seconds = np.uint32(date + self.JAN_1970)
-        self.useconds = np.uint32((date - int(date)) * 1e6)
+        if isinstance(date,numbers.Number):
+            self._dt = datetime.datetime.utcfromtimestamp(date)
+        elif isinstance(date,datetime.datetime):
+            self._dt = date
+        elif isinstance(date,datetime.date):
+            self._dt = datetime.datetime.combine(date,datetime.time())
+
+    @property
+    def era(self):
+        delta = (self._dt - self.EPOCH).total_seconds()
+        return np.uint32( int(delta) / 2**32)
+
+    @property
+    def seconds(self):
+        delta = self._dt - self.EPOCH
+        return np.uint32(np.trunc(delta.total_seconds()))
+
+    @seconds.setter
+    def seconds(self,value):
+        delta = datetime.timedelta(seconds=value)
+        self._dt = self.EPOCH + delta
+
+    @property
+    def useconds(self):
+        delta = self._dt - self.EPOCH
+        return np.uint32(np.modf(delta.total_seconds())[0] * 1e6)
 
     def __repr__(self):
         return '<%s "%s" at 0x%x>' % (self.__class__.__name__, str(self), id(self))
 
     def __str__(self):
-        ts = self.seconds + (self.useconds/1e6)
-        return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(ts))
+        return self._dt.isoformat()
 
-    def to_ntp(self):
+    def to_ntp64(self):
         '''
-        Converts the IonTime object into a RFC 5905 (NTPv4) compliant 64bit time stamp
-        '''
-        left = np.uint64(self.seconds << 32)
-        right = np.uint64(self.useconds / 1e6 * self.FRAC)
-        timestamp = np.uint64(left + right)
-        return self.htonll(timestamp)
+        Returns the NTPv4 64bit timestamp
+           0                   1                   2                   3
+           0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+          |                            Seconds                            |
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+          |                            Fraction                           |
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         
-    def from_ntp(self, val):
+        '''
+        delta = (self._dt - self.EPOCH).total_seconds()
+        seconds = np.uint32(np.trunc(delta))
+        fraction = np.uint32((delta - int(delta)) * 2**32)
+        timestamp = struct.pack(self.ntpv4_timestamp, seconds, fraction)
+        return timestamp
+    
+    @classmethod
+    def from_ntp64(cls, val):
         '''
         Converts a RFC 5905 (NTPv4) compliant 64bit time stamp into an IonTime object
         '''
-        val = self.htonll(val)
-        left = np.uint64(val) >> np.uint64(32)
-        right = (np.uint64(val) & np.uint64(4294967295)) * 1e6 / self.FRAC
-        self.seconds = np.uint32(left)
-        self.useconds = np.uint32(right)
+        seconds, fraction = struct.unpack(cls.ntpv4_timestamp, val)
+        it = cls()
+        it.seconds = seconds + (fraction *1e0 / 2**32)
+        return it
+
+
+    def to_ntp_date(self):
+        '''
+        Returns the NTPv4 128bit date timestamp
+           0                   1                   2                   3
+           0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+          |                           Era Number                          |
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+          |                           Era Offset                          |
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+          |                                                               |
+          |                           Fraction                            |
+          |                                                               |
+          +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        '''
+        delta = (self._dt - self.EPOCH).total_seconds()
+        era = int(delta) / (2**32)
+        offset = np.uint32(np.trunc(delta)) # Overflow does all the work for us
+        fraction = np.uint64((delta - int(delta)) * 2**64)
+        ntp_date = struct.pack(self.ntpv4_date, era,offset,fraction)
+        return ntp_date
+
+    @classmethod
+    def from_ntp_date(cls, value):
+        '''
+        Returns an IonTime object based on the 128bit RFC 5905 (NTPv4) Date Format
+        '''
+        era, seconds, fraction = struct.unpack(cls.ntpv4_date, value)
+        it = cls()
+        it.seconds = (era * 2**32) + seconds + (fraction * 1e0 / 2**64)
+        return it
 
     def to_string(self):
         '''
         Creates a hexidecimal string of the NTP time stamp (serialization)
         '''
-        val = self.to_ntp().tostring()
+        val = self.to_ntp64()
+        assert len(val) == 8
         arr = [0] * 8
         for i in xrange(8):
             arr[i] = '%02x' % ord(val[i])
-        return ''.join(arr)
+        retval = ''.join(arr)
+        return retval
 
-    def from_string(self, s):
+    def to_extended_string(self):
         '''
-        Changes this IonTime object to reflect the stringified time stamp
+        Creates a hexidecimal string of the NTP date format (serialization)
         '''
-        s = self.htonstr(s)
-        ntp_ts = np.uint64(int(s,16))
-        self.from_ntp(ntp_ts)
+        val = self.to_ntp_date()
+        assert len(val) == 16
+        arr = [0] * 16
+        for i in xrange(16):
+            arr[i] = '%02x' % ord(val[i])
+        retval = ''.join(arr)
+        return retval
+
+    
+    @classmethod
+    def from_string(cls, s):
+        '''
+        Creates an IonTime object from the serialized time stamp
+        '''
+        assert len(s) == 16
+        arr = [0] * 8
+        for i in xrange(8):
+            arr[i] = chr(int(s[2*i:2*i+2],16))
+        retval = ''.join(arr)
+        it = cls.from_ntp64(retval)
+        return it
+    
+    @classmethod
+    def from_extended_string(cls, s):
+        '''
+        Creates an IonTime object from the serialized extended time stamp
+        '''
+        assert len(s) == 32
+        arr = [0] * 16 
+        for i in xrange(16):
+            arr[i] = chr(int(s[2*i:2*i+2],16))
+        retval = ''.join(arr)
+        it = cls.from_ntp_date(retval)
+        return it
 
     def to_unix(self):
         '''

--- a/pyon/util/test/test_ion_time.py
+++ b/pyon/util/test/test_ion_time.py
@@ -11,26 +11,33 @@ from pyon.util.ion_time import IonTime
 from nose.plugins.attrib import attr
 import time
 import numpy as np
+import datetime
 
 @attr('UNIT')
 class IonTimeUnitTest(PyonTestCase):
     def test_time_ntp_fidelity(self):
         it1 = IonTime()
-        ntp_ts = it1.to_ntp()
-        it2 = IonTime()
-        it2.from_ntp(ntp_ts)
+        ntp_ts = it1.to_ntp64()
+        it2 = IonTime.from_ntp64(ntp_ts)
         self.assertEquals(it1.seconds,it2.seconds)
         self.assertTrue(np.abs(it1.useconds - it2.useconds) <= 1)
 
     def test_time_string_fidelity(self):
         it1 = IonTime()
         ntp_str = it1.to_string()
-        it2 = IonTime()
-        it2.from_string(ntp_str)
+        it2 = IonTime.from_string(ntp_str)
         
         self.assertEquals(it1.seconds,it2.seconds)
         self.assertTrue(np.abs(it1.useconds - it2.useconds) <= 1)
 
+    def test_extended_string_fidelity(self):
+        it1 = IonTime()
+        s = it1.to_extended_string()
+        it2 = IonTime.from_extended_string(s)
+
+        self.assertEquals(it1.era, it2.era)
+        self.assertEquals(it1.seconds, it2.seconds)
+        self.assertEquals(it1.useconds, it2.useconds)
 
     def test_unix_time_fidelity(self):
         ts = time.time()
@@ -38,4 +45,23 @@ class IonTimeUnitTest(PyonTestCase):
 
         ts_2 = it1.to_unix()
         self.assertTrue(np.abs(ts - ts_2) <= 1e-3)
+
+    def test_ntp_compatability(self):
+        unix_day = IonTime(datetime.datetime(1970,1,1))
+        self.assertEquals(unix_day.era , 0)
+        self.assertEquals(unix_day.seconds , 2208988800)
+
+        utc_day = IonTime(datetime.datetime(1972,1,1))
+        self.assertEquals(utc_day.era , 0)
+        self.assertEquals(utc_day.seconds , 2272060800)
+
+        millen_day = IonTime(datetime.datetime(2000,1,1))
+        self.assertEquals(millen_day.era , 0)
+        self.assertEquals(millen_day.seconds , 3155673600)
+
+        ntp_era1 = IonTime(datetime.datetime(2036,2,8))
+        self.assertEquals(ntp_era1.era , 1)
+        self.assertEquals(ntp_era1.seconds , 63104)
+        self.assertEquals(ntp_era1.to_unix() , 2086041600.)
+
 


### PR DESCRIPTION
Luke: more changes to time

Changes the internal representation of IonTime to use python datetime
objects. This will address the conern about days after 2036-02-08, the
end of epoch 0 in NTPv4 (RFC 5905).

Luke: Better time representation
- Adopts exceptionally better time representation
- Capable of handling rollover (2036-02-07) problem
- Concept of "ERA" from NTPv4 RFC 5905
- Uses struct in lieu of manual bit mangling

Luke: adds era and compatability tests

Luke: adds int test for extension
