### PR TITLE
Luke: more changes to time

### DIFF
--- a/pyon/util/test/test_ion_time.py
+++ b/pyon/util/test/test_ion_time.py
@@ -11,14 +11,14 @@ from pyon.util.ion_time import IonTime
 from nose.plugins.attrib import attr
 import time
 import numpy as np
+import datetime
 
 @attr('UNIT')
 class IonTimeUnitTest(PyonTestCase):
     def test_time_ntp_fidelity(self):
         it1 = IonTime()
-        ntp_ts = it1.to_ntp()
-        it2 = IonTime()
-        it2.from_ntp(ntp_ts)
+        ntp_ts = it1.to_ntp64()
+        it2 = IonTime.from_ntp64(ntp_ts)
         self.assertEquals(it1.seconds,it2.seconds)
         self.assertTrue(np.abs(it1.useconds - it2.useconds) <= 1)
 
@@ -37,4 +37,23 @@ class IonTimeUnitTest(PyonTestCase):
 
         ts_2 = it1.to_unix()
         self.assertTrue(np.abs(ts - ts_2) <= 1e-3)
+
+    def test_ntp_compatability(self):
+        unix_day = IonTime(datetime.datetime(1970,1,1))
+        self.assertEquals(unix_day.era , 0)
+        self.assertEquals(unix_day.seconds , 2208988800)
+
+        utc_day = IonTime(datetime.datetime(1972,1,1))
+        self.assertEquals(utc_day.era , 0)
+        self.assertEquals(utc_day.seconds , 2272060800)
+
+        millen_day = IonTime(datetime.datetime(2000,1,1))
+        self.assertEquals(millen_day.era , 0)
+        self.assertEquals(millen_day.seconds , 3155673600)
+
+        ntp_era1 = IonTime(datetime.datetime(2036,2,8))
+        self.assertEquals(ntp_era1.era , 1)
+        self.assertEquals(ntp_era1.seconds , 63104)
+        self.assertEquals(ntp_era1.to_unix() , 2086041600.)
+
 


### PR DESCRIPTION
Changes the internal representation of IonTime to use python datetime
objects. This will address the conern about days after 2036-02-08, the
end of epoch 0 in NTPv4 (RFC 5909).

Luke: Better time representation
- Adopts exceptionally better time representation
- Capable of handling rollover (2036-02-07) problem
- Concept of "ERA" from NTPv4 RFC 5905
- Uses struct in lieu of manual bit mangling

Luke: adds era and compatability tests
