### PR TITLE
Luke: adds FSM patch to endpoint

### DIFF
--- a/pyon/ion/stream.py
+++ b/pyon/ion/stream.py
@@ -221,5 +221,7 @@ class SimpleStreamSubscriber(Subscriber):
     @classmethod
     def new_subscriber(cls, container, exchange_name, callback):
         xn = container.ex_manager.create_xn_queue(exchange_name)
-        return cls(name=xn, callback=callback)
+        instance = cls(name=xn,callback=callback)
+        setattr(instance,'xn',xn)
+        return instance
 

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -569,6 +569,11 @@ class ListeningBaseEndpoint(BaseEndpoint):
 
         mos = []
         newch = self._chan.accept(n=num, timeout=timeout)
+        qsize = newch._recv_queue.qsize()
+        if qsize==0:
+            self._chan.exit_accept()
+            return []
+
         for x in xrange(newch._recv_queue.qsize()):
             mo = self.MessageObject(newch.recv(), newch, self.create_endpoint(existing_channel=newch))
             mo.make_body()      # puts through EP interceptors


### PR DESCRIPTION
- If a Subscriber gets all messages through get_all_msgs when there are
  no messages available in the queue the FSM does not advance to
  ACCEPTED as it would if there were messages which fails subsequent
  calls.
