### PR TITLE
Luke: adds change_logging_level

### DIFF
--- a/pyon/util/log.py
+++ b/pyon/util/log.py
@@ -12,6 +12,16 @@ import sys
 import socket
 from logging.handlers import SysLogHandler, SYSLOG_UDP_PORT
 
+
+DEBUG     = 'DEBUG'
+INFO      = 'INFO'
+WARNING   = 'WARNING'
+ERROR     = 'ERROR'
+CRITICAL  = 'CRITICAL'
+EXCEPTION = 'EXCEPTION'
+
+
+
 class StackFormatter(logging.Formatter):
     def __init__(self,*a,**b):
         super(StackFormatter,self).__init__(*a,**b)
@@ -208,3 +218,10 @@ BaseConfigurator.importer = staticmethod(_import)
 
 log = get_scoped_log()
 
+def change_logging_level(level):
+    assert level in [DEBUG, INFO, WARNING, ERROR, CRITICAL]
+    from pyon.core.log import LOGGING_CFG
+    import logging.config
+    for k,v in LOGGING_CFG['loggers'].iteritems():
+        LOGGING_CFG['loggers'][k]['level'] = level
+    logging.config.dictConfig(LOGGING_CFG)

--- a/pyon/util/log.py
+++ b/pyon/util/log.py
@@ -218,10 +218,15 @@ BaseConfigurator.importer = staticmethod(_import)
 
 log = get_scoped_log()
 
-def change_logging_level(level):
+def change_logging_level(logger,level):
     assert level in [DEBUG, INFO, WARNING, ERROR, CRITICAL]
     from pyon.core.log import LOGGING_CFG
+    assert logger=='all' or logger in LOGGING_CFG['loggers']
     import logging.config
-    for k,v in LOGGING_CFG['loggers'].iteritems():
-        LOGGING_CFG['loggers'][k]['level'] = level
+    if logger=='all':
+        for k,v in LOGGING_CFG['loggers'].iteritems():
+            LOGGING_CFG['loggers'][k]['level'] = level
+    else:
+        LOGGING_CFG['loggers'][logger]['level'] = level
+
     logging.config.dictConfig(LOGGING_CFG)

--- a/pyon/util/log.py
+++ b/pyon/util/log.py
@@ -219,6 +219,15 @@ BaseConfigurator.importer = staticmethod(_import)
 log = get_scoped_log()
 
 def change_logging_level(logger,level):
+    '''
+    Change the logging level for a given logger or for all loggers by using 'all'
+
+    Example:
+      from pyon.util.log import CRITICAL,DEBUG, change_logging_level
+      change_logging_level('all', CRITICAL)
+      change_logging_level('pyon', DEBUG)
+
+    '''
     assert level in [DEBUG, INFO, WARNING, ERROR, CRITICAL]
     from pyon.core.log import LOGGING_CFG
     assert logger=='all' or logger in LOGGING_CFG['loggers']


### PR DESCRIPTION
@daf 
@mmeisinger
@mauricemanning
@jamie-cyber1

This adds the ability to interactively change the logging level, it's intended use is for debugging interactively.
Example:

```
from pyon.util.log import change_logging_level
change_logging_level('pyon','CRITICAL')
```
