### PR TITLE
Yaml for parameter dicts

### DIFF
--- a/pyon/ion/param_dict_ctxt.py
+++ b/pyon/ion/param_dict_ctxt.py
@@ -2,23 +2,51 @@
 
 """Resource specific definitions"""
 from pyon.util.config import Config
-from pyon.util.containers import DotDict, named_any, get_ion_ts
+from pyon.util.containers import DotDict
 
-# Resource Types
+# Parameter Dictionaries loaded from param_dict_defs.yml
 ParamDict = DotDict()
-ParamType = DotDict()
-PD = ParamType
 
+# PD = A DotDict containing all the defined parameter dictionaries defined in the param_dict_defs.yml
+ParamDictType = DotDict()
+PD = ParamDictType
 
-def get_predicate_type_list():
-    ParamDict = Config(["res/config/param_dict_defs.yml"]).data
+# PD_CTXT = A DotDict that maps each parameter dictionary to relevant parameter contexts
+# This is also loaded from the contents of param_dict_defs.yml
+ParamDictToCtxt = DotDict()
+PD_CTXT = ParamDictToCtxt
+
+# PCTXT = A DotDict containing all the parameter context defined in the param_context_defs.yml
+ParamContextType = DotDict()
+PCTXT = ParamContextType
+
+ParamDict = Config(["res/config/param_dict_defs.yml"]).data
+ParamContext = Config(["res/config/param_context_defs.yml"]).data
+
+def get_param_dict_list():
     return ParamDict.keys()
+
+def get_param_ctxt_for_param_dict():
+    for k,v in ParamDict.items():
+        ParamDictToCtxt[k] = v.keys()
+    return ParamDictToCtxt
+
+def get_param_context_list():
+    return ParamContext.keys()
 
 def load_definitions():
     """Loads PD as a DotDict
     """
     # Param Dict Types
-    pt_list = get_predicate_type_list()
-    ParamType.clear()
-    ParamType.update(zip(pt_list, pt_list))
+    pt_list = get_param_dict_list()
+    pctxt_list = get_param_context_list()
+
+    ParamDictType.clear()
+    ParamDictType.update(zip(pt_list, pt_list))
+
+    ParamContextType.clear()
+    ParamContextType.update(zip(pctxt_list, pctxt_list))
+
+    ParamDictToCtxt = get_param_ctxt_for_param_dict()
+
 

--- a/pyon/ion/param_dict_ctxt.py
+++ b/pyon/ion/param_dict_ctxt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Resource specific definitions"""
+"""A module to load as DotDicts the parameter dictionary and context definitions from their respective yml files"""
 from pyon.util.config import Config
 from pyon.util.containers import DotDict
 


### PR DESCRIPTION
This enables us to load from corresponding ymls the parameter dict types, parameter context types and the DotDict that maps each parameter dictionary to its parameter contexts.

Therefore, it enables us to do the following (which is similar to how RT, PRED, etc are used):

> <> from pyon.ion.param_dict_ctxt import PD, PD_CTXT, PCTXT
> 
> <> PD
> --> 
> {'CondParamDict': 'CondParamDict',
>  'PressParamDict': 'PressParamDict',
>  'SalParamDict': 'SalParamDict',
>  'TempParamDict': 'TempParamDict'}
> 
> <> PD_CTXT
> --> 
> {'CondParamDict': ['lat', 'lon', 'time', 'depth', 'conductivity'],
>  'PressParamDict': ['lat', 'lon', 'time', 'depth', 'pressure'],
>  'SalParamDict': ['lat', 'lon', 'time', 'depth', 'salinity'],
>  'TempParamDict': ['lat', 'lon', 'time', 'depth', 'temperature']}
> 
> <> PCTXT
> --> 
> {'Conductivity': 'Conductivity',
>  'Depth': 'Depth',
>  'Lat': 'Lat',
>  'Lon': 'Lon',
>  'Pressure': 'Pressure',
>  'Raw': 'Raw',
>  'Salinity': 'Salinity',
>  'Temperature': 'Temperature',
>  'Time': 'Time'}
> 
> <> PD.CondParamDict
> --> 'CondParamDict'
> 
> <> PD_CTXT.SalParamDict
> --> ['lat', 'lon', 'time', 'depth', 'salinity']
> 
> <> PCTXT.Raw
> --> 'Raw'
> 
> <> from pyon.ion.param_dict_ctxt import ParamDict, ParamContext
> 
> <> ParamDict
> --> 
> {'CondParamDict': {'conductivity': 'Conductivity',
>   'depth': 'Depth',
>   'lat': 'Lat',
>   'lon': 'Lon',
>   'time': 'Time'},
>  'PressParamDict': {'depth': 'Depth',
>   'lat': 'Lat',
>   'lon': 'Lon',
>   'pressure': 'Pressure',
>   'time': 'Time'},
>  'SalParamDict': {'depth': 'Depth',
>   'lat': 'Lat',
>   'lon': 'Lon',
>   'salinity': 'Salinity',
>   'time': 'Time'},
>  'TempParamDict': {'depth': 'Depth',
>   'lat': 'Lat',
>   'lon': 'Lon',
>   'temperature': 'Temperature',
>   'time': 'Time'}}
> 
> <> ParamContext
> --> 
> {'Conductivity': {'docstring': 'References the conductivity',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'uom': 'siemens_per_meter'},
>  'Depth': {'docstring': 'References the depth',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'ref_frame': 'AxisTypeEnum.HEIGHT',
>   'uom': 'meters'},
>  'Lat': {'docstring': 'References the latitude',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'ref_frame': 'AxisTypeEnum.LAT',
>   'uom': 'degree_north'},
>  'Lon': {'docstring': 'References the longitude',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'ref_frame': 'AxisTypeEnum.LON',
>   'uom': 'degree_east'},
>  'Pressure': {'docstring': 'References the pressure',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'uom': 'Pascal'},
>  'Raw': {'docstring': 'References raw data',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'uom': 'unknown'},
>  'Salinity': {'docstring': 'References the salinity',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'uom': 'PSU'},
>  'Temperature': {'docstring': 'References the temperature',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.float32)',
>   'uom': 'degree_Celsius'},
>  'Time': {'docstring': 'References the time',
>   'fill_value': '0e0',
>   'param_type': 'QuantityType(value_encoding=np.int64)',
>   'ref_frame': 'AxisTypeEnum.TIME',
>   'uom': 'seconds since 1970-01-01'}}
