### PR TITLE
Refactor datastore ops for mult assoc search.

### DIFF
--- a/pyon/datastore/couchdb/couchdb_config.py
+++ b/pyon/datastore/couchdb/couchdb_config.py
@@ -229,6 +229,14 @@ function(doc) {
     emit(doc.s, doc.o);
   }
 }""",
+            },
+        'by_subject_bulk':{
+            'map':"""
+function(doc) {
+  if(doc.type_ == "Association") {
+    emit(doc.o, doc.s);
+  }
+}""",
             }
     },
 

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -508,7 +508,7 @@ class CouchDB_DataStore(DataStore):
 
         return False
 
-    def find_associations_mult(self, subjects, id_only=False):
+    def find_objects_mult(self, subjects, id_only=False):
         """
         Returns a list of associations for a given list of subjects
         """
@@ -523,6 +523,23 @@ class CouchDB_DataStore(DataStore):
             return ids, assocs
         else:
             return self.read_mult(ids), assocs
+
+    def find_subjects_mult(self, objects, id_only=False):
+        """
+        Returns a list of associations for a given list of objects
+        """
+        ds, datastore_name = self._get_datastore()
+        validate_is_instance(objects, list, 'objects is not a list of resource_ids')
+        view_args = dict(keys=objects, include_docs=True)
+        results = self.query_view(self._get_viewname("association", "by_subject_bulk"), view_args)
+        ids = [i['value'] for i in results]
+        assocs = [i['doc'] for i in results]
+        self._count(find_assocs_mult_call=1, find_assocs_mult_obj=len(ids))
+        if id_only:
+            return ids, assocs
+        else:
+            return self.read_mult(ids), assocs
+
 
     def find_objects(self, subject, predicate=None, object_type=None, id_only=False, **kwargs):
         log.debug("find_objects(subject=%s, predicate=%s, object_type=%s, id_only=%s", subject, predicate, object_type, id_only)

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -315,9 +315,12 @@ class ResourceRegistry(object):
     def find_associations(self, subject="", predicate="", object="", assoc_type=None, id_only=False):
         return self.rr_store.find_associations(subject, predicate, object, assoc_type, id_only=id_only)
 
-    def find_associations_mult(self, subjects=[], id_only=False):
-        return self.rr_store.find_associations_mult(subjects=subjects, id_only=id_only)
+    def find_objects_mult(self, subjects=[], id_only=False):
+        return self.rr_store.find_objects_mult(subjects=subjects, id_only=id_only)
 
+    def find_subjects_mult(self, objects=[], id_only=False):
+        return self.rr_store.find_subjects_mult(objects=objects, id_only=id_only)
+    
     def get_association(self, subject="", predicate="", object="", assoc_type=None, id_only=False):
         if predicate:
             assoc_type = assoc_type or AT.H2H


### PR DESCRIPTION
Separates the multiple association searching into two separate methods: `find_subjects_mult` and `find_objects_mult`.  Two essential methods for proper search and navigation.
