### PR TITLE
Add couch attachment based on Prashant's commits

### DIFF
--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -407,10 +407,10 @@ class IonObjectDeserializer(IonObjectSerializationBase):
             ion_obj = self._obj_registry.new(type)
             for k, v in objc.iteritems():
 
-                #in CouchDB _attachments contains attachment metadata
-                #in pyon we have metadata in the document itself and so we discard _attachments
-
-                if k != "type_" and k!= "_attachments":
+                # CouchDB adds _attachments and puts metadata in it
+                # in pyon metadata is in the document
+                # so we discard _attachments while transforming between the two
+                if k != "type_" and k != "_attachments":
                     setattr(ion_obj, k, v)
 
             return ion_obj

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -407,7 +407,11 @@ class IonObjectDeserializer(IonObjectSerializationBase):
             # which preserves things like IonEnumObject and invokes the setattr behavior we want there.
             ion_obj = self._obj_registry.new(type)
             for k, v in objc.iteritems():
-                if k != "type_":
+
+                #in CouchDB _attachments contains attachment metadata
+                #in pyon we have metadata in the document itself and so we discard _attachments
+
+                if k != "type_" and k!= "_attachments":
                     setattr(ion_obj, k, v)
 
             return ion_obj

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -287,7 +287,6 @@ class IonObjectBase(object):
 class IonMessageObjectBase(IonObjectBase):
     pass
 
-
 def walk(o, cb):
     """
     Utility method to do recursive walking of a possible iterable (inc dicts) and do inline transformations.

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -1081,4 +1081,3 @@ class CouchDB_DataStore(DataStore):
     def _count(self, datastore=None, **kwargs):
         datastore = datastore or self.datastore_name
         self._stats.count(namespace=datastore, **kwargs)
-

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -173,8 +173,8 @@ class CouchDB_DataStore(DataStore):
                                attachments=attachments)
 
     def create_doc(self, doc, object_id=None, attachments=None, datastore_name=""):
-        """Persists the document using the optionally suggested doc_id, and creates attachments
-        to it.
+        """
+        Persists the document using the optionally suggested doc_id, and creates attachments to it.
         Returns the identifier and version number of the document
         """
         ds, datastore_name = self._get_datastore(datastore_name)
@@ -188,7 +188,7 @@ class CouchDB_DataStore(DataStore):
         log.debug('Creating new object %s/%s' % (datastore_name, doc["_id"]))
         log.debug('create doc contents: %s', doc)
 
-        #Add the attachments if indicated
+        # Add the attachments if indicated
         if not attachments is None:
             if isinstance(attachments, dict):
                 doc['_attachments'] = attachments
@@ -204,8 +204,10 @@ class CouchDB_DataStore(DataStore):
         return (id, version)
 
     def list_attachments(self, doc):
-        """ Accepts both a doc as str (meaning an id) or a doc as dict (meaning a full document)
-            Returns the _attachment from the document, a dict, as it comes from couchdb"""
+        """
+        Accepts both a doc as str (meaning an id) or a doc as dict (meaning a full document)
+        Returns the _attachment from the document, a dict, as it comes from couchdb.
+        """
         if not isinstance(doc, str):
             doc = doc["_id"]
 
@@ -222,8 +224,10 @@ class CouchDB_DataStore(DataStore):
         self._count(update_attachment=1)
 
     def create_attachment(self, doc, attachment_name, data, content_type=None, datastore_name=""):
-        """ Assumes that the document already exists and creates attachment to it
-            doc can be either id or the whole document """
+        """
+        Assumes that the document already exists and creates attachment to it
+        doc can be either id or the whole document
+        """
         if not isinstance(attachment_name, str):
             raise BadRequest("attachment name is not string")
         if not isinstance(data, str) and not isinstance(data, file):

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -203,6 +203,16 @@ class CouchDB_DataStore(DataStore):
         id, version = res
         return (id, version)
 
+    def list_attachments(self,doc,datastore_name=""):
+        """ Accepts both a doc as str (meaning an id) or a doc as dict (meaning a full document)
+        -- returns the _attachment from the document, a dict, as it comes from couchdb"""
+        if not isinstance(doc, str):
+            doc = doc["_id"]
+
+        doc = self.read_doc(doc_id=doc)
+
+        return doc["_attachments"]
+
     def update_attachment(self, doc, attachment_name, data, content_type=None, datastore_name=""):
         log.debug("updating attachment %s", attachment_name)
         self.create_attachment(doc=doc, attachment_name=attachment_name, data=data,

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -203,9 +203,9 @@ class CouchDB_DataStore(DataStore):
         id, version = res
         return (id, version)
 
-    def list_attachments(self,doc,datastore_name=""):
+    def list_attachments(self, doc):
         """ Accepts both a doc as str (meaning an id) or a doc as dict (meaning a full document)
-        -- returns the _attachment from the document, a dict, as it comes from couchdb"""
+            Returns the _attachment from the document, a dict, as it comes from couchdb"""
         if not isinstance(doc, str):
             doc = doc["_id"]
 

--- a/pyon/datastore/test/test_datastores.py
+++ b/pyon/datastore/test/test_datastores.py
@@ -20,6 +20,7 @@ OWNER_OF = "XOWNER_OF"
 HAS_A = "XHAS_A"
 BASED_ON = "XBASED_ON"
 
+
 @attr('UNIT', group='datastore')
 class Test_DataStores(IonIntegrationTestCase):
 
@@ -61,6 +62,7 @@ class Test_DataStores(IonIntegrationTestCase):
                 ds.delete_doc("badid", "BadDataStoreNamePerCouchDB")
 
             self._do_test_views(CouchDB_DataStore(datastore_name='ion_test_ds', profile=DataStore.DS_PROFILE.RESOURCES), is_persistent=True)
+            self._do_test_attach(CouchDB_DataStore(datastore_name='ion_test_ds', profile=DataStore.DS_PROFILE.RESOURCES))
 
         except socket.error:
             raise SkipTest('Failed to connect to CouchDB')
@@ -227,28 +229,6 @@ class Test_DataStores(IonIntegrationTestCase):
         self.assertTrue(data_set_read_obj.description == "Real-time water data for Choptank River near Greensboro, MD")
         self.assertTrue('type_' in data_set_read_obj)
 
-        #test attachment related stuff
-        #create attachment
-        ds_id_and_rev={}
-        filename='resource.attachment'
-        ds_id_and_rev['_id']=write_tuple_1[0]
-        ds_id_and_rev['_rev']=write_tuple_1[1]
-        content = "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x10\x00\x00\x00\x10\x08\x03\x00\x00\x00(-\x0fS\x00\x00\x00\x03sBIT\x08\x08\x08\xdb\xe1O\xe0\x00\x00\x00~PLTEf3\x00\xfc\xf7\xe0\xee\xcc\x00\xd3\xa0\x00\xcc\x99\x00\xec\xcdc\x9fl\x00\xdd\xb2\x00\xff\xff\xff|I\x00\xf9\xdb\x00\xdd\xb5\x19\xd9\xad\x10\xb6\x83\x00\xf8\xd6\x00\xf2\xc5\x00\xd8\xab\x00n;\x00\xff\xcc\x00\xd6\xa4\t\xeb\xb8\x00\x83Q\x00\xadz\x00\xff\xde\x00\xff\xd6\x00\xd6\xa3\x00\xdf\xaf\x00\xde\xad\x10\xbc\x8e\x00\xec\xbe\x00\xec\xd4d\xff\xe3\x00tA\x00\xf6\xc4\x00\xf6\xce\x00\xa5u\x00\xde\xa5\x00\xf7\xbd\x00\xd6\xad\x08\xdd\xaf\x19\x8cR\x00\xea\xb7\x00\xee\xe9\xdf\xc5\x00\x00\x00\tpHYs\x00\x00\n\xf0\x00\x00\n\xf0\x01B\xac4\x98\x00\x00\x00\x1ctEXtSoftware\x00Adobe Fireworks CS4\x06\xb2\xd3\xa0\x00\x00\x00\x15tEXtCreation Time\x0029/4/09Oq\xfdE\x00\x00\x00\xadIDAT\x18\x95M\x8f\x8d\x0e\x820\x0c\x84;ZdC~f\x07\xb2\x11D\x86\x89\xe8\xfb\xbf\xa0+h\xe2\x97\\\xd2^\x93\xb6\x07:1\x9f)q\x9e\xa5\x06\xad\xd5\x13\x8b\xac,\xb3\x02\x9d\x12C\xa1-\xef;M\x08*\x19\xce\x0e?\x1a\xeb4\xcc\xd4\x0c\x831\x87V\xca\xa1\x1a\xd3\x08@\xe4\xbd\xb7\x15P;\xc8\xd4{\x91\xbf\x11\x90\xffg\xdd\x8di\xfa\xb6\x0bs2Z\xff\xe8yg2\xdc\x11T\x96\xc7\x05\xa5\xef\x96+\xa7\xa59E\xae\xe1\x84cm^1\xa6\xb3\xda\x85\xc8\xd8/\x17se\x0eN^'\x8c\xc7\x8e\x88\xa8\xf6p\x8e\xc2;\xc6.\xd0\x11.\x91o\x12\x7f\xcb\xa5\xfe\x00\x89]\x10:\xf5\x00\x0e\xbf\x00\x00\x00\x00IEND\xaeB`\x82"
-        data_store.create_attachment(doc=ds_id_and_rev, content=content, filename=filename, content_type=None, datastore_name="")
-        #create attachment with no content
-        #read attachment
-        content_read=data_store.read_attachment(doc_id=ds_id_and_rev['_id'], filename=filename, datastore_name="")
-        self.assertEquals(content, content_read)
-        #update attachment
-        #delete attachment
-        data_store.delete_attachment(doc=ds_id_and_rev, attachment_filename=filename)
-        #try to read the attachment that has been deleted
-        content_read=data_store.read_attachment(doc_id=ds_id_and_rev['_id'], filename=filename, datastore_name="")
-        self.assertIsNone(content_read)
-        #since the attachment tests have updated the data_set, read it again for the subsequent tests
-        #to work as they should
-        data_set_read_obj = data_store.read(data_set_uuid)
-
         # Update DataSet's Description field and write
         data_set_read_obj.description = "Updated Description"
         write_tuple_2 = data_store.update(data_set_read_obj)
@@ -258,39 +238,6 @@ class Test_DataStores(IonIntegrationTestCase):
         data_set_read_obj_2 = data_store.read(data_set_uuid)
         self.assertTrue(data_set_read_obj_2._id == data_set_uuid)
         self.assertTrue(data_set_read_obj_2.description == "Updated Description")
-
-
-        #create attachment to the updated document
-        updated_ds_id_and_rev={}
-        updated_ds_id_and_rev['_id']=write_tuple_2[0]
-        updated_ds_id_and_rev['_rev']=write_tuple_2[1]
-        some_text = "SOME TEXT"
-        updated_filename='updated.attachment'
-        data_store.create_attachment(doc=updated_ds_id_and_rev, content=some_text, filename=updated_filename, content_type=None, datastore_name="")
-
-        #test attachment related stuff
-        #read the attachment
-        content_read=data_store.read_attachment(doc_id=updated_ds_id_and_rev['_id'], filename=updated_filename, datastore_name="")
-        self.assertEquals(some_text, content_read)
-        #delete attachment from the wrong revision
-        self.assertFalse(data_store.delete_attachment(doc=ds_id_and_rev, attachment_filename=updated_filename))
-        #update attachment
-        data_store.update_attachment(updated_ds_id_and_rev, old_filename=updated_filename, new_filename=filename, content=content)
-        #read the old attachment
-        content_read=data_store.read_attachment(doc_id=updated_ds_id_and_rev['_id'], filename=updated_filename, datastore_name="")
-        self.assertIsNone(content_read)
-        #interestingly, deleting an attachment that does not exist works
-        #even though attempting to delete an attachment that exists but for another revision fails
-        self.assertTrue(data_store.delete_attachment(doc=updated_ds_id_and_rev, attachment_filename=updated_filename))
-        #read the new attachment
-        content_read=data_store.read_attachment(doc_id=updated_ds_id_and_rev['_id'], filename=filename, datastore_name="")
-        self.assertEquals(content, content_read)
-        #delete the right attachment from the right revision
-        self.assertTrue(data_store.delete_attachment(doc=updated_ds_id_and_rev, attachment_filename=filename))
-        #since the attachment tests have updated the data_set, read it again for the subsequent tests
-        #to work as they should
-        data_set_read_obj_2 = data_store.read(data_set_uuid)
-
 
         # List all the revisions of DataSet in data store, should be two
         res = data_store.list_object_revisions(data_set_uuid)
@@ -352,6 +299,147 @@ class Test_DataStores(IonIntegrationTestCase):
 
         # Assert data store is now gone
         self.assertNotIn('ion_test_ds', data_store.list_datastores())
+
+    def _do_test_attach(self, data_store):
+
+        self.data_store = data_store
+        self.resources = {}
+
+        # Create an Ion object with default values set (if any)
+        data_set = IonObject('DataSet')
+        self.assertTrue(isinstance(data_set, interface.objects.DataSet))
+
+        # Assign values to object fields
+        data_set.description = "Real-time water data for Choptank River near Greensboro, MD"
+
+        # Write DataSet object"
+        write_tuple_1 = data_store.create(data_set)
+
+        # Save off the object UUID
+        data_set_uuid = write_tuple_1[0]
+
+        # Read back the HEAD version of the object
+        data_set_read_obj = data_store.read(data_set_uuid)
+
+        # Update DataSet's Description field and write
+        data_set_read_obj.description = "Updated Description"
+        write_tuple_2 = data_store.update(data_set_read_obj)
+
+        # test attachment related stuff
+        # create attachment
+        ds_id_and_rev = {}
+        attachment_name = 'resource.attachment'
+        ds_id_and_rev['_id'] = write_tuple_2[0]
+        ds_id_and_rev['_rev'] = write_tuple_2[1]
+        data = "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x10\x00\x00\x00\x10\x08\x03\x00\x00\x00(-\x0fS\x00\x00\x00\x03sBIT\x08\x08\x08\xdb\xe1O\xe0\x00\x00\x00~PLTEf3\x00\xfc\xf7\xe0\xee\xcc\x00\xd3\xa0\x00\xcc\x99\x00\xec\xcdc\x9fl\x00\xdd\xb2\x00\xff\xff\xff|I\x00\xf9\xdb\x00\xdd\xb5\x19\xd9\xad\x10\xb6\x83\x00\xf8\xd6\x00\xf2\xc5\x00\xd8\xab\x00n;\x00\xff\xcc\x00\xd6\xa4\t\xeb\xb8\x00\x83Q\x00\xadz\x00\xff\xde\x00\xff\xd6\x00\xd6\xa3\x00\xdf\xaf\x00\xde\xad\x10\xbc\x8e\x00\xec\xbe\x00\xec\xd4d\xff\xe3\x00tA\x00\xf6\xc4\x00\xf6\xce\x00\xa5u\x00\xde\xa5\x00\xf7\xbd\x00\xd6\xad\x08\xdd\xaf\x19\x8cR\x00\xea\xb7\x00\xee\xe9\xdf\xc5\x00\x00\x00\tpHYs\x00\x00\n\xf0\x00\x00\n\xf0\x01B\xac4\x98\x00\x00\x00\x1ctEXtSoftware\x00Adobe Fireworks CS4\x06\xb2\xd3\xa0\x00\x00\x00\x15tEXtCreation Time\x0029/4/09Oq\xfdE\x00\x00\x00\xadIDAT\x18\x95M\x8f\x8d\x0e\x820\x0c\x84;ZdC~f\x07\xb2\x11D\x86\x89\xe8\xfb\xbf\xa0+h\xe2\x97\\\xd2^\x93\xb6\x07:1\x9f)q\x9e\xa5\x06\xad\xd5\x13\x8b\xac,\xb3\x02\x9d\x12C\xa1-\xef;M\x08*\x19\xce\x0e?\x1a\xeb4\xcc\xd4\x0c\x831\x87V\xca\xa1\x1a\xd3\x08@\xe4\xbd\xb7\x15P;\xc8\xd4{\x91\xbf\x11\x90\xffg\xdd\x8di\xfa\xb6\x0bs2Z\xff\xe8yg2\xdc\x11T\x96\xc7\x05\xa5\xef\x96+\xa7\xa59E\xae\xe1\x84cm^1\xa6\xb3\xda\x85\xc8\xd8/\x17se\x0eN^'\x8c\xc7\x8e\x88\xa8\xf6p\x8e\xc2;\xc6.\xd0\x11.\x91o\x12\x7f\xcb\xa5\xfe\x00\x89]\x10:\xf5\x00\x0e\xbf\x00\x00\x00\x00IEND\xaeB`\x82"
+        some_text = "SOME TEXT"
+
+        # create attachment with no data
+        with self.assertRaises(BadRequest):
+            data_store.create_attachment(doc=ds_id_and_rev, data=None,
+                                         attachment_name=attachment_name,
+                                         content_type=None, datastore_name="")
+
+        # create attachment with no attachment
+        with self.assertRaises(BadRequest):
+            data_store.create_attachment(doc=ds_id_and_rev, data=data,
+                                         attachment_name=None, content_type=None, datastore_name="")
+
+        #create attachment by passing a doc parameter that
+        # is a dictionary containing _rev and _id elements
+        data_store.create_attachment(doc=ds_id_and_rev, data=data,
+                                     attachment_name=attachment_name,
+                                     content_type=None, datastore_name="")
+
+        # read attachment by passing a doc parameter that is a dictionary
+        # containing _rev and _id elements and verify that the content read
+        # is same as the content put in
+        content_read = data_store.read_attachment(doc=ds_id_and_rev,
+                                                  attachment_name=attachment_name,
+                                                  datastore_name="")
+        self.assertEquals(data, content_read)
+
+        # update attachment by passing a doc parameter that is a dictionary
+        # containing _rev and _id elements
+        data_store.update_attachment(ds_id_and_rev, attachment_name, data=some_text)
+
+        # read the attachment passing only the doc _id and verify that content has changed
+        content_read = data_store.read_attachment(doc=ds_id_and_rev['_id'],
+                                                  attachment_name=attachment_name,
+                                                  datastore_name="")
+        self.assertNotEquals(data, content_read)
+        self.assertEquals(some_text, content_read)
+
+        # delete attachment by passing a doc parameter that is a dictionary containing _rev
+        # and _id elements
+        data_store.delete_attachment(doc=ds_id_and_rev, attachment_name=attachment_name)
+
+        # interestingly, deleting an attachment that does not exist works
+        # pass a doc parameter that is a dictionary containing _rev and _id elements
+        data_store.delete_attachment(doc=ds_id_and_rev['_id'], attachment_name='no_such_file')
+
+        #create attachment by passing a doc parameter that is string indicating _id
+        data_store.create_attachment(doc=ds_id_and_rev['_id'], data=data,
+                                     attachment_name=attachment_name, content_type=None,
+                                     datastore_name="")
+
+        # read attachment by passing a doc parameter that is a string indicating _id
+        # and verify that the content read is same as the content put in
+        content_read = data_store.read_attachment(doc=ds_id_and_rev['_id'],
+                                                  attachment_name=attachment_name,
+                                                  datastore_name="")
+        self.assertEquals(data, content_read)
+
+        # update attachment by passing a doc parameter that is a string indicating _id
+        data_store.update_attachment(ds_id_and_rev['_id'], attachment_name, data=some_text)
+
+        #refer to a previous version of the document
+        updated_ds_id_and_rev = {}
+        updated_ds_id_and_rev['_id'] = write_tuple_1[0]
+        updated_ds_id_and_rev['_rev'] = write_tuple_1[1]
+
+        # deleting attachment from the previous (wrong) revision raises document update conflict
+        with self.assertRaises(Exception):
+            data_store.delete_attachment(doc=updated_ds_id_and_rev, attachment_name=attachment_name)
+
+        # operations on previous versions are not allowed
+        with self.assertRaises(Exception):
+            data_store.create_attachment(doc=updated_ds_id_and_rev, data=some_text,
+                                         attachment_name=attachment_name, content_type=None,
+                                         datastore_name="")
+
+        # send in an incorrect document _id
+        with self.assertRaises(NotFound):
+            data_store.create_attachment(doc="incorrect_id", data=data,
+                                         attachment_name=attachment_name, content_type=None,
+                                         datastore_name="")
+
+        # send in an incorrect document _id
+        with self.assertRaises(NotFound):
+            data_store.read_attachment(doc="incorrect_id", attachment_name=attachment_name,
+                                       datastore_name="")
+
+        # send in an incorrect attachment_name
+        with self.assertRaises(NotFound):
+            data_store.read_attachment(doc=ds_id_and_rev['_id'],
+                                       attachment_name="incorrect_attachment", datastore_name="")
+
+        # send in an incorrect document_id
+        with self.assertRaises(NotFound):
+            data_store.update_attachment(doc="incorrect_id", attachment_name=attachment_name,
+                                         data=some_text)
+
+        # send in an incorrect attachment_name; this should work because update creates an
+        # attachment when it can't find an attachment to update
+        data_store.update_attachment(ds_id_and_rev['_id'], attachment_name="incorrect_attachment",
+                                     data=some_text)
+
+        # send in an incorrect attachment_name; interestingly, this is not an error
+        data_store.delete_attachment(doc=ds_id_and_rev['_id'], attachment_name='no_such_file')
+
+        # send in an incorrect document_id
+        with self.assertRaises(NotFound):
+            data_store.delete_attachment(doc="incorrect_id", attachment_name='no_such_file')
 
     def _do_test_views(self, data_store, is_persistent=False):
         self.data_store = data_store

--- a/pyon/datastore/test/test_datastores.py
+++ b/pyon/datastore/test/test_datastores.py
@@ -227,6 +227,28 @@ class Test_DataStores(IonIntegrationTestCase):
         self.assertTrue(data_set_read_obj.description == "Real-time water data for Choptank River near Greensboro, MD")
         self.assertTrue('type_' in data_set_read_obj)
 
+        #test attachment related stuff
+        #create attachment
+        ds_id_and_rev={}
+        filename='resource.attachment'
+        ds_id_and_rev['_id']=write_tuple_1[0]
+        ds_id_and_rev['_rev']=write_tuple_1[1]
+        content = "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x10\x00\x00\x00\x10\x08\x03\x00\x00\x00(-\x0fS\x00\x00\x00\x03sBIT\x08\x08\x08\xdb\xe1O\xe0\x00\x00\x00~PLTEf3\x00\xfc\xf7\xe0\xee\xcc\x00\xd3\xa0\x00\xcc\x99\x00\xec\xcdc\x9fl\x00\xdd\xb2\x00\xff\xff\xff|I\x00\xf9\xdb\x00\xdd\xb5\x19\xd9\xad\x10\xb6\x83\x00\xf8\xd6\x00\xf2\xc5\x00\xd8\xab\x00n;\x00\xff\xcc\x00\xd6\xa4\t\xeb\xb8\x00\x83Q\x00\xadz\x00\xff\xde\x00\xff\xd6\x00\xd6\xa3\x00\xdf\xaf\x00\xde\xad\x10\xbc\x8e\x00\xec\xbe\x00\xec\xd4d\xff\xe3\x00tA\x00\xf6\xc4\x00\xf6\xce\x00\xa5u\x00\xde\xa5\x00\xf7\xbd\x00\xd6\xad\x08\xdd\xaf\x19\x8cR\x00\xea\xb7\x00\xee\xe9\xdf\xc5\x00\x00\x00\tpHYs\x00\x00\n\xf0\x00\x00\n\xf0\x01B\xac4\x98\x00\x00\x00\x1ctEXtSoftware\x00Adobe Fireworks CS4\x06\xb2\xd3\xa0\x00\x00\x00\x15tEXtCreation Time\x0029/4/09Oq\xfdE\x00\x00\x00\xadIDAT\x18\x95M\x8f\x8d\x0e\x820\x0c\x84;ZdC~f\x07\xb2\x11D\x86\x89\xe8\xfb\xbf\xa0+h\xe2\x97\\\xd2^\x93\xb6\x07:1\x9f)q\x9e\xa5\x06\xad\xd5\x13\x8b\xac,\xb3\x02\x9d\x12C\xa1-\xef;M\x08*\x19\xce\x0e?\x1a\xeb4\xcc\xd4\x0c\x831\x87V\xca\xa1\x1a\xd3\x08@\xe4\xbd\xb7\x15P;\xc8\xd4{\x91\xbf\x11\x90\xffg\xdd\x8di\xfa\xb6\x0bs2Z\xff\xe8yg2\xdc\x11T\x96\xc7\x05\xa5\xef\x96+\xa7\xa59E\xae\xe1\x84cm^1\xa6\xb3\xda\x85\xc8\xd8/\x17se\x0eN^'\x8c\xc7\x8e\x88\xa8\xf6p\x8e\xc2;\xc6.\xd0\x11.\x91o\x12\x7f\xcb\xa5\xfe\x00\x89]\x10:\xf5\x00\x0e\xbf\x00\x00\x00\x00IEND\xaeB`\x82"
+        data_store.create_attachment(doc=ds_id_and_rev, content=content, filename=filename, content_type=None, datastore_name="")
+        #create attachment with no content
+        #read attachment
+        content_read=data_store.read_attachment(doc_id=ds_id_and_rev['_id'], filename=filename, datastore_name="")
+        self.assertEquals(content, content_read)
+        #update attachment
+        #delete attachment
+        data_store.delete_attachment(doc=ds_id_and_rev, attachment_filename=filename)
+        #try to read the attachment that has been deleted
+        content_read=data_store.read_attachment(doc_id=ds_id_and_rev['_id'], filename=filename, datastore_name="")
+        self.assertIsNone(content_read)
+        #since the attachment tests have updated the data_set, read it again for the subsequent tests
+        #to work as they should
+        data_set_read_obj = data_store.read(data_set_uuid)
+
         # Update DataSet's Description field and write
         data_set_read_obj.description = "Updated Description"
         write_tuple_2 = data_store.update(data_set_read_obj)
@@ -236,6 +258,39 @@ class Test_DataStores(IonIntegrationTestCase):
         data_set_read_obj_2 = data_store.read(data_set_uuid)
         self.assertTrue(data_set_read_obj_2._id == data_set_uuid)
         self.assertTrue(data_set_read_obj_2.description == "Updated Description")
+
+
+        #create attachment to the updated document
+        updated_ds_id_and_rev={}
+        updated_ds_id_and_rev['_id']=write_tuple_2[0]
+        updated_ds_id_and_rev['_rev']=write_tuple_2[1]
+        some_text = "SOME TEXT"
+        updated_filename='updated.attachment'
+        data_store.create_attachment(doc=updated_ds_id_and_rev, content=some_text, filename=updated_filename, content_type=None, datastore_name="")
+
+        #test attachment related stuff
+        #read the attachment
+        content_read=data_store.read_attachment(doc_id=updated_ds_id_and_rev['_id'], filename=updated_filename, datastore_name="")
+        self.assertEquals(some_text, content_read)
+        #delete attachment from the wrong revision
+        self.assertFalse(data_store.delete_attachment(doc=ds_id_and_rev, attachment_filename=updated_filename))
+        #update attachment
+        data_store.update_attachment(updated_ds_id_and_rev, old_filename=updated_filename, new_filename=filename, content=content)
+        #read the old attachment
+        content_read=data_store.read_attachment(doc_id=updated_ds_id_and_rev['_id'], filename=updated_filename, datastore_name="")
+        self.assertIsNone(content_read)
+        #interestingly, deleting an attachment that does not exist works
+        #even though attempting to delete an attachment that exists but for another revision fails
+        self.assertTrue(data_store.delete_attachment(doc=updated_ds_id_and_rev, attachment_filename=updated_filename))
+        #read the new attachment
+        content_read=data_store.read_attachment(doc_id=updated_ds_id_and_rev['_id'], filename=filename, datastore_name="")
+        self.assertEquals(content, content_read)
+        #delete the right attachment from the right revision
+        self.assertTrue(data_store.delete_attachment(doc=updated_ds_id_and_rev, attachment_filename=filename))
+        #since the attachment tests have updated the data_set, read it again for the subsequent tests
+        #to work as they should
+        data_set_read_obj_2 = data_store.read(data_set_uuid)
+
 
         # List all the revisions of DataSet in data store, should be two
         res = data_store.list_object_revisions(data_set_uuid)

--- a/pyon/datastore/test/test_datastores.py
+++ b/pyon/datastore/test/test_datastores.py
@@ -47,7 +47,7 @@ class Test_DataStores(IonIntegrationTestCase):
                 ds.list_object_revisions("badid", "BadDataStoreNamePerCouchDB")
 
             with self.assertRaises(BadRequest):
-                ds.create_doc({"foo": "bar"}, "", "BadDataStoreNamePerCouchDB")
+                ds.create_doc({"foo": "bar"}, "", datastore_name="BadDataStoreNamePerCouchDB")
 
             with self.assertRaises(BadRequest):
                 ds.read_doc("badid", "3", "BadDataStoreNamePerCouchDB")

--- a/pyon/datastore/test/test_datastores.py
+++ b/pyon/datastore/test/test_datastores.py
@@ -393,6 +393,14 @@ class Test_DataStores(IonIntegrationTestCase):
         # update attachment by passing a doc parameter that is a string indicating _id
         data_store.update_attachment(ds_id_and_rev['_id'], attachment_name, data=some_text)
 
+        # create another attachment and
+        # list attachments by passing a doc parameter that is a dictionary
+        # containing _rev and _id elements
+        data_store.create_attachment(doc=ds_id_and_rev['_id'], data=data,
+                                     attachment_name=attachment_name+"_01", content_type=None,
+                                     datastore_name="")
+        _attachments = data_store.list_attachments(doc=ds_id_and_rev)
+
         #refer to a previous version of the document
         updated_ds_id_and_rev = {}
         updated_ds_id_and_rev['_id'] = write_tuple_1[0]

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -219,9 +219,6 @@ class ResourceRegistry(object):
             if type(attachment.content) is not str:
                 raise BadRequest("Attachment content must be str")
 
-            #saving encoded attachment content separately
-            #content = base64.encodestring(attachment.content)
-            # and emptying it from the attachment object
             attachment.content=base64.encodestring(attachment.content)
 
         elif attachment.attachment_type == AttachmentType.ASCII:

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -61,23 +61,23 @@ class ResourceRegistry(object):
         cur_time = get_ion_ts()
         object.ts_created = cur_time
         object.ts_updated = cur_time
-
         if object_id is None:
-            object_id = create_unique_resource_id()
-
-            obj = self.rr_store.create(object, object_id, attachments=attachments)
-        obj_id, rev = obj
+            new_res_id = create_unique_resource_id()
+        else:
+            new_res_id = object_id
+        res = self.rr_store.create(object, new_res_id, attachments=attachments)
+        res_id, rev = res
 
         if actor_id and actor_id != 'anonymous':
-            log.debug("Associate resource_id=%s with owner=%s" % (obj_id, actor_id))
-            self.rr_store.create_association(obj_id, PRED.hasOwner, actor_id)
+            log.debug("Associate resource_id=%s with owner=%s" % (res_id, actor_id))
+            self.rr_store.create_association(res_id, PRED.hasOwner, actor_id)
 
         self.event_pub.publish_event(event_type="ResourceModifiedEvent",
-                                     origin=obj_id, origin_type=object._get_type(),
+                                     origin=res_id, origin_type=object._get_type(),
                                      sub_type="CREATE",
                                      mod_type=ResourceModificationType.CREATE)
 
-        return obj
+        return res
 
     def _create_mult(self, res_list):
         cur_time = get_ion_ts()

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -234,7 +234,6 @@ class ResourceRegistry(object):
 
         att_id,_ = self.create(attachment,includeAttachment=True)
 
-
         if resource_id:
             self.rr_store.create_association(resource_id, PRED.hasAttachment, att_id)
 

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -225,7 +225,7 @@ class ResourceRegistry(object):
         if attachment is None:
             raise BadRequest("Object not present")
         if not isinstance(attachment, Attachment):
-                raise BadRequest("Object is not an Attachment")
+            raise BadRequest("Object is not an Attachment")
 
         attachment.object_id = resource_id if resource_id else ""
 
@@ -362,7 +362,7 @@ class ResourceRegistry(object):
                            attr_name=None, attr_value=None, alt_id="", alt_id_ns="",
                            limit=None, skip=None, descending=None, id_only=True):
         return self.rr_store.find_resources_ext(restype=restype, lcstate=lcstate, name=name,
-                keyword=keyword, nested_type=nested_type,
+            keyword=keyword, nested_type=nested_type,
             attr_name=attr_name, attr_value=attr_value, alt_id=alt_id, alt_id_ns=alt_id_ns,
             limit=limit, skip=skip, descending=descending,
             id_only=id_only)

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -273,8 +273,8 @@ class ResourceRegistry(object):
                          limit=0, descending=False, include_content=False, id_only=True):
         key = [resource_id]
         att_res = self.rr_store.find_by_view("attachment", "by_resource", start_key=key,
-                                             end_key=list(key),
-            descending=descending, limit=limit, id_only=True)
+                                             end_key=list(key), descending=descending, limit=limit,
+                                             id_only=True)
 
         att_ids = [att[0] for att in att_res if not keyword or keyword in att[1][2]]
         if id_only:

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -25,7 +25,7 @@ class ResourceRegistry(object):
     """
     Class that uses a data store to provide a resource registry.
     """
-    DEFAULT_ATTACHMENT_NAME='resource.attachment'
+    DEFAULT_ATTACHMENT_NAME = 'resource.attachment'
 
     def __init__(self, datastore_manager=None):
 
@@ -42,10 +42,12 @@ class ResourceRegistry(object):
         """
         self.rr_store.close()
 
-    def create(self, object=None, actor_id=None, object_id=None,attachments=None):
-        """Accepts object that is to be stored in the data store and tags them with additional data (timestamp and such)
-        If actor_id is provided, creates hasOwner association with objects.
-        If attachments are provided (in {filename:content} form) they get attached to the object.
+    def create(self, object=None, actor_id=None, object_id=None, attachments=None):
+        """Accepts object that is to be stored in the data store and tags them with additional data
+        (timestamp and such) If actor_id is provided, creates hasOwner association with objects.
+        If attachments are provided
+        (in dict(att1=dict(data=xyz), att2=dict(data=aaa, content_type='text/plain') form)
+        they get attached to the object.
         Returns a tuple containing object and revision identifiers. """
         if object is None:
             raise BadRequest("Object not present")
@@ -59,10 +61,11 @@ class ResourceRegistry(object):
         cur_time = get_ion_ts()
         object.ts_created = cur_time
         object.ts_updated = cur_time
+
         if object_id is None:
             object_id = create_unique_resource_id()
 
-        obj = self.rr_store.create(object, object_id, attachments=attachments)
+            obj = self.rr_store.create(object, object_id, attachments=attachments)
         obj_id, rev = obj
 
         if actor_id and actor_id != 'anonymous':
@@ -117,8 +120,8 @@ class ResourceRegistry(object):
 
         object.ts_updated = get_ion_ts()
         if res_obj.lcstate != object.lcstate:
-            log.warn("Cannot modify %s life cycle state in update current=%s given=%s. " + 
-                     "DO NOT REUSE THE SAME OBJECT IN CREATE THEN UPDATE", 
+            log.warn("Cannot modify %s life cycle state in update current=%s given=%s. " +
+                     "DO NOT REUSE THE SAME OBJECT IN CREATE THEN UPDATE",
                       type(res_obj).__name__, res_obj.lcstate, object.lcstate)
             object.lcstate = res_obj.lcstate
 
@@ -225,38 +228,38 @@ class ResourceRegistry(object):
         if attachment.attachment_type == AttachmentType.BLOB:
             if type(attachment.content) is not str:
                 raise BadRequest("Attachment content must be str")
-            attachment.content=base64.encodestring(attachment.content)
+            attachment.content = base64.encodestring(attachment.content)
         elif attachment.attachment_type == AttachmentType.ASCII:
             if type(attachment.content) is not str:
                 raise BadRequest("Attachment content must be str")
-            attachment.content=base64.encodestring(attachment.content)
+            attachment.content = base64.encodestring(attachment.content)
         elif attachment.attachment_type == AttachmentType.OBJECT:
             pass
         else:
             raise BadRequest("Unknown attachment-type: %s" % attachment.attachment_type)
 
-        content=attachment.content
+        content = dict(data=attachment.content, content_type=attachment.content_type)
         attachment.content = self.DEFAULT_ATTACHMENT_NAME
 
-        att_id,_ = self.create(attachment, attachments={self.DEFAULT_ATTACHMENT_NAME:content})
-        #for multiple attachments use the below sample
-        #att_id,_ = self.create(attachment, attachments={self.DEFAULT_ATTACHMENT_NAME:content,self.DEFAULT_ATTACHMENT_NAME:content})
+        att_id, _ = self.create(attachment, attachments={self.DEFAULT_ATTACHMENT_NAME: content})
+        # for multiple attachments use the below sample
+        # attachments = dict(att1=dict(data=xyz), att2=dict(data=aaa, content_type='text/plain')
 
         if resource_id:
             self.rr_store.create_association(resource_id, PRED.hasAttachment, att_id)
 
         return att_id
 
-    def read_attachment(self, attachment_id='',include_content=False):
-        """Returns the metadata of an attachment. Unless indicated otherwise the content returned is only a name to the
-        actual attachment content"""
+    def read_attachment(self, attachment_id='', include_content=False):
+        """Returns the metadata of an attachment. Unless indicated otherwise the content returned
+        is only a name to the actual attachment content"""
         attachment = self.read(attachment_id)
         if not isinstance(attachment, Attachment):
             raise Inconsistent("Object in datastore must be Attachment, not %s" % type(attachment))
 
         if include_content:
-            attachment.content = self.rr_store.read_attachment(attachment_id, filename=attachment.content)
-
+            attachment.content = self.rr_store.read_attachment(attachment_id,
+                                                               attachment_name=attachment.content)
             if attachment.attachment_type == AttachmentType.BLOB:
                 if type(attachment.content) is not str:
                     raise BadRequest("Attachment content must be str")
@@ -269,7 +272,8 @@ class ResourceRegistry(object):
     def find_attachments(self, resource_id='', keyword=None,
                          limit=0, descending=False, include_content=False, id_only=True):
         key = [resource_id]
-        att_res = self.rr_store.find_by_view("attachment", "by_resource", start_key=key, end_key=list(key),
+        att_res = self.rr_store.find_by_view("attachment", "by_resource", start_key=key,
+                                             end_key=list(key),
             descending=descending, limit=limit, id_only=True)
 
         att_ids = [att[0] for att in att_res if not keyword or keyword in att[1][2]]
@@ -279,7 +283,8 @@ class ResourceRegistry(object):
             atts = self.rr_store.read_mult(att_ids)
             if include_content:
                 for att in atts:
-                    att.content = self.rr_store.read_attachment(doc_id=att._id, filename=att.content)
+                    att.content = self.rr_store.read_attachment(doc=att._id,
+                                                                attachment_name=att.content)
             return atts
 
     def create_association(self, subject=None, predicate=None, object=None, assoc_type=None):
@@ -351,7 +356,7 @@ class ResourceRegistry(object):
                            attr_name=None, attr_value=None, alt_id="", alt_id_ns="",
                            limit=None, skip=None, descending=None, id_only=True):
         return self.rr_store.find_resources_ext(restype=restype, lcstate=lcstate, name=name,
-            keyword=keyword, nested_type=nested_type,
+                keyword=keyword, nested_type=nested_type,
             attr_name=attr_name, attr_value=attr_value, alt_id=alt_id, alt_id_ns=alt_id_ns,
             limit=limit, skip=skip, descending=descending,
             id_only=id_only)

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -43,12 +43,14 @@ class ResourceRegistry(object):
         self.rr_store.close()
 
     def create(self, object=None, actor_id=None, object_id=None, attachments=None):
-        """Accepts object that is to be stored in the data store and tags them with additional data
+        """
+        Accepts object that is to be stored in the data store and tags them with additional data
         (timestamp and such) If actor_id is provided, creates hasOwner association with objects.
         If attachments are provided
         (in dict(att1=dict(data=xyz), att2=dict(data=aaa, content_type='text/plain') form)
         they get attached to the object.
-        Returns a tuple containing object and revision identifiers. """
+        Returns a tuple containing object and revision identifiers.
+        """
         if object is None:
             raise BadRequest("Object not present")
         if not isinstance(object, IonObjectBase):
@@ -215,8 +217,10 @@ class ResourceRegistry(object):
                                      old_state=old_state, new_state=target_lcstate)
 
     def create_attachment(self, resource_id='', attachment=None):
-        """Persists the given attachment and associates it with the given resource.
-        Returns an identifier for the attachment from the data store."""
+        """
+        Persists the given attachment and associates it with the given resource.
+        Returns an identifier for the attachment from the data store.
+        """
 
         if attachment is None:
             raise BadRequest("Object not present")
@@ -251,8 +255,10 @@ class ResourceRegistry(object):
         return att_id
 
     def read_attachment(self, attachment_id='', include_content=False):
-        """Returns the metadata of an attachment. Unless indicated otherwise the content returned
-        is only a name to the actual attachment content"""
+        """
+        Returns the metadata of an attachment. Unless indicated otherwise the content returned
+        is only a name to the actual attachment content.
+        """
         attachment = self.read(attachment_id)
         if not isinstance(attachment, Attachment):
             raise Inconsistent("Object in datastore must be Attachment, not %s" % type(attachment))

--- a/pyon/ion/test/test_resregistry.py
+++ b/pyon/ion/test/test_resregistry.py
@@ -98,11 +98,11 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att = Attachment(content=binary, attachment_type=AttachmentType.ASCII)
         aid2 = self.rr.create_attachment(iid, att)
 
-        #test that attachments are without content by default
+        # test that attachments are without content by default
         att1 = self.rr.read_attachment(aid2)
         self.assertEquals('resource.attachment', att1.content)
 
-        #tests that the attachment content can be read
+        # tests that the attachment content can be read
         att1 = self.rr.read_attachment(aid2, include_content=True)
         self.assertEquals(binary, att1.content)
 
@@ -115,11 +115,11 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att_ids = self.rr.find_attachments(iid, id_only=True, descending=True, limit=1)
         self.assertEquals(att_ids, [aid2])
 
-        #test that content can be included
+        # test that content can be included
         atts = self.rr.find_attachments(iid, id_only=False, include_content=True, limit=1)
         self.assertEquals(atts[0].content, att1.content)
 
-        #test that content can be excluded and is the default
+        # test that content can be excluded and is the default
         atts = self.rr.find_attachments(iid, id_only=False, limit=1)
         self.assertEquals(atts[0].content, 'resource.attachment')
 
@@ -147,7 +147,7 @@ class TestResourceRegistry(IonIntegrationTestCase):
         self.assertEquals(len(att_objs), 1)
         self.assertEquals(att_objs[0].content, "SOME TEXT")
 
-        #tests that attachments can be retrieved without content
+        # tests that attachments can be retrieved without content
         att_objs_without_content = self.rr.find_attachments(iid, keyword="FOO", id_only=False,
                                                             include_content=False)
         self.assertEquals(len(att_objs_without_content), 1)

--- a/pyon/ion/test/test_resregistry.py
+++ b/pyon/ion/test/test_resregistry.py
@@ -3,7 +3,6 @@
 __author__ = 'Michael Meisinger'
 
 import uuid
-from unittest import SkipTest
 
 from pyon.core.bootstrap import IonObject
 from pyon.core.exception import NotFound, Inconsistent
@@ -98,6 +97,10 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att = Attachment(content=base64.encodestring(binary), attachment_type=AttachmentType.ASCII)
         aid2 = self.rr.create_attachment(iid, att)
 
+        #tests that attachments can be read without content
+        att1 = self.rr.read_attachment(aid2,includeContent=False)
+        self.assertEquals(None, att1.content)
+        #tests that attachments have content by default
         att1 = self.rr.read_attachment(aid2)
         self.assertEquals(binary, base64.decodestring(att1.content))
 
@@ -135,3 +138,8 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att_objs = self.rr.find_attachments(iid, keyword="FOO", id_only=False)
         self.assertEquals(len(att_objs), 1)
         self.assertEquals(att_objs[0].content, "SOME TEXT")
+
+        #tests that attachments can be retrieved without content
+        att_objs_without_content = self.rr.find_attachments(iid, keyword="FOO", id_only=False,include_content=False)
+        self.assertEquals(len(att_objs_without_content), 1)
+        self.assertEquals(att_objs_without_content[0].content, "pyon.attachment")

--- a/pyon/ion/test/test_resregistry.py
+++ b/pyon/ion/test/test_resregistry.py
@@ -12,6 +12,7 @@ from nose.plugins.attrib import attr
 
 from interface.objects import Attachment, AttachmentType
 
+
 @attr('INT', group='resource')
 class TestResourceRegistry(IonIntegrationTestCase):
 
@@ -85,12 +86,12 @@ class TestResourceRegistry(IonIntegrationTestCase):
 
         # Owner creation tests
         instrument = IonObject("InstrumentDevice", name='instrument')
-        iid,_ = self.rr.create(instrument)
+        iid, _ = self.rr.create(instrument)
 
         att = Attachment(content=binary, attachment_type=AttachmentType.BLOB)
         aid1 = self.rr.create_attachment(iid, att)
 
-        att1 = self.rr.read_attachment(aid1,include_content=True)
+        att1 = self.rr.read_attachment(aid1, include_content=True)
         self.assertEquals(binary, att1.content)
 
         import base64
@@ -102,7 +103,7 @@ class TestResourceRegistry(IonIntegrationTestCase):
         self.assertEquals('resource.attachment', att1.content)
 
         #tests that the attachment content can be read
-        att1 = self.rr.read_attachment(aid2,include_content=True)
+        att1 = self.rr.read_attachment(aid2, include_content=True)
         self.assertEquals(binary, att1.content)
 
         att_ids = self.rr.find_attachments(iid, id_only=True)
@@ -115,12 +116,12 @@ class TestResourceRegistry(IonIntegrationTestCase):
         self.assertEquals(att_ids, [aid2])
 
         #test that content can be included
-        atts = self.rr.find_attachments(iid, id_only=False,include_content=True, limit=1)
+        atts = self.rr.find_attachments(iid, id_only=False, include_content=True, limit=1)
         self.assertEquals(atts[0].content, att1.content)
 
         #test that content can be excluded and is the default
         atts = self.rr.find_attachments(iid, id_only=False, limit=1)
-        self.assertEquals(atts[0].content,'resource.attachment')
+        self.assertEquals(atts[0].content, 'resource.attachment')
 
         self.rr.delete_attachment(aid1)
 
@@ -132,7 +133,8 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att_ids = self.rr.find_attachments(iid, id_only=True)
         self.assertEquals(att_ids, [])
 
-        att = Attachment(content="SOME TEXT", attachment_type=AttachmentType.ASCII, keywords=['BAR','FOO'])
+        att = Attachment(content="SOME TEXT", attachment_type=AttachmentType.ASCII,
+                         keywords=['BAR', 'FOO'])
         aid3 = self.rr.create_attachment(iid, att)
 
         att_ids = self.rr.find_attachments(iid, keyword="NONE", id_only=True)
@@ -146,6 +148,7 @@ class TestResourceRegistry(IonIntegrationTestCase):
         self.assertEquals(att_objs[0].content, "SOME TEXT")
 
         #tests that attachments can be retrieved without content
-        att_objs_without_content = self.rr.find_attachments(iid, keyword="FOO", id_only=False,include_content=False)
+        att_objs_without_content = self.rr.find_attachments(iid, keyword="FOO", id_only=False,
+                                                            include_content=False)
         self.assertEquals(len(att_objs_without_content), 1)
         self.assertEquals(att_objs_without_content[0].content, "resource.attachment")

--- a/pyon/ion/test/test_resregistry.py
+++ b/pyon/ion/test/test_resregistry.py
@@ -90,19 +90,20 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att = Attachment(content=binary, attachment_type=AttachmentType.BLOB)
         aid1 = self.rr.create_attachment(iid, att)
 
-        att1 = self.rr.read_attachment(aid1)
+        att1 = self.rr.read_attachment(aid1,include_content=True)
         self.assertEquals(binary, att1.content)
 
         import base64
-        att = Attachment(content=base64.encodestring(binary), attachment_type=AttachmentType.ASCII)
+        att = Attachment(content=binary, attachment_type=AttachmentType.ASCII)
         aid2 = self.rr.create_attachment(iid, att)
 
-        #tests that attachments can be read without content
-        att1 = self.rr.read_attachment(aid2,includeContent=False)
-        self.assertEquals(None, att1.content)
-        #tests that attachments have content by default
+        #test that attachments are without content by default
         att1 = self.rr.read_attachment(aid2)
-        self.assertEquals(binary, base64.decodestring(att1.content))
+        self.assertEquals('resource.attachment', att1.content)
+
+        #tests that the attachment content can be read
+        att1 = self.rr.read_attachment(aid2,include_content=True)
+        self.assertEquals(binary, att1.content)
 
         att_ids = self.rr.find_attachments(iid, id_only=True)
         self.assertEquals(att_ids, [aid1, aid2])
@@ -113,8 +114,13 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att_ids = self.rr.find_attachments(iid, id_only=True, descending=True, limit=1)
         self.assertEquals(att_ids, [aid2])
 
-        atts = self.rr.find_attachments(iid, id_only=False, limit=1)
+        #test that content can be included
+        atts = self.rr.find_attachments(iid, id_only=False,include_content=True, limit=1)
         self.assertEquals(atts[0].content, att1.content)
+
+        #test that content can be excluded and is the default
+        atts = self.rr.find_attachments(iid, id_only=False, limit=1)
+        self.assertEquals(atts[0].content,'resource.attachment')
 
         self.rr.delete_attachment(aid1)
 
@@ -135,11 +141,11 @@ class TestResourceRegistry(IonIntegrationTestCase):
         att_ids = self.rr.find_attachments(iid, keyword="FOO", id_only=True)
         self.assertEquals(att_ids, [aid3])
 
-        att_objs = self.rr.find_attachments(iid, keyword="FOO", id_only=False)
+        att_objs = self.rr.find_attachments(iid, keyword="FOO", id_only=False, include_content=True)
         self.assertEquals(len(att_objs), 1)
         self.assertEquals(att_objs[0].content, "SOME TEXT")
 
         #tests that attachments can be retrieved without content
         att_objs_without_content = self.rr.find_attachments(iid, keyword="FOO", id_only=False,include_content=False)
         self.assertEquals(len(att_objs_without_content), 1)
-        self.assertEquals(att_objs_without_content[0].content, "pyon.attachment")
+        self.assertEquals(att_objs_without_content[0].content, "resource.attachment")


### PR DESCRIPTION
Using Prashant's commits, I've merged his changes and enabled couch attachments for the resregistry Attachment resources. The capability of binary couch is available in general now
