### PR TITLE
Adds get_extended_url

### DIFF
--- a/pyon/util/file_sys.py
+++ b/pyon/util/file_sys.py
@@ -186,6 +186,20 @@ class FileSystem(object):
 
             return os.path.join(path, '%s%s' % (clean_name[4:], ext))
 
+    @staticmethod
+    def get_extended_url(path):
+        if ':' in path:
+            s = path.split(':')
+            base = FileSystem.FS_DIRECTORY[s[0]]
+            path = os.path.join(base, s[1])
+            try:
+                os.makedirs(path)
+            except OSError:
+                pass
+        return path
+
+
+
 
     @staticmethod
     def mktemp(filename='', ext=''):


### PR DESCRIPTION
`get_extended_url` Understands the internal file system better and can be
used to get a currect file system url using existing file system
resources.  Example:

``` python
path = FileSystem.get_extended_url('RESOURCE:logs/syslogs')
```

Will return : /tmp/ion/res/logs/syslogs (and the tree will be created)
