### PR TITLE
Use the Service status field to determine service availability

### DIFF
--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -24,9 +24,8 @@ from pyon.util.log import log
 from pyon.ion.resource import RT, PRED
 from pyon.net.channel import RecvChannel
 from pyon.net.transport import NameTrio, TransportError
-from gevent import Timeout
 
-from interface.objects import ProcessStateEnum, CapabilityContainer, Service, Process
+from interface.objects import ProcessStateEnum, CapabilityContainer, Service, Process, ServiceStateEnum
 
 from couchdb.http import ResourceNotFound
 
@@ -765,7 +764,7 @@ class ProcManager(object):
             else:
                 # We are starting the first process of a service instance
                 # TODO: This should be created by the HA Service agent in the future
-                svc_obj = Service(name=process_instance.name, exchange_name=process_instance._proc_listen_name)
+                svc_obj = Service(name=process_instance.name, exchange_name=process_instance._proc_listen_name, state=ServiceStateEnum.READY)
                 process_instance._proc_svc_id, _ = self.container.resource_registry.create(svc_obj)
 
                 # Create association to service definition resource

--- a/pyon/core/governance/governance_controller.py
+++ b/pyon/core/governance/governance_controller.py
@@ -5,7 +5,7 @@ __author__ = 'Stephen P. Henrie'
 __license__ = 'Apache 2.0'
 
 import types
-from pyon.core.bootstrap import CFG
+from pyon.core.bootstrap import CFG, get_service_registry
 from pyon.core.governance.governance_dispatcher import GovernanceDispatcher
 from pyon.util.log import log
 from pyon.ion.resource import RT, PRED, LCS
@@ -355,14 +355,10 @@ class GovernanceController(object):
         Method to verify if the Policy Management Service is running in the system. If the container cannot connect to
         the RR then assume it is remote container so do not try to access Policy Management Service
         """
-        try:
-            if hasattr(self.container, 'has_capability') and self.container.has_capability('RESOURCE_REGISTRY'):
-                policy_services, _ = self.container.resource_registry.find_resources(restype=RT.Service,name='policy_management')
-                if policy_services:
-                    return True
-            return False
-        except Exception:
-            return False
+        policy_service = get_service_registry().is_service_available('policy_management', True)
+        if policy_service:
+            return True
+        return False
 
     # Methods for managing operation specific policy
     def get_process_operation_dict(self, process_name):

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -255,7 +255,7 @@ class ExchangeManager(object):
             if exchange_service:
                 return True
 
-            return False
+        return False
 
 
 

--- a/pyon/ion/exchange.py
+++ b/pyon/ion/exchange.py
@@ -6,7 +6,7 @@ __author__ = 'Michael Meisinger, Dave Foster'
 __license__ = 'Apache 2.0'
 
 from pyon.core import bootstrap
-from pyon.core.bootstrap import CFG
+from pyon.core.bootstrap import CFG, get_service_registry
 from pyon.net import messaging
 from pyon.net.transport import NameTrio, TransportError, ComposableTransport
 from pyon.util.log import log
@@ -242,6 +242,7 @@ class ExchangeManager(object):
         self._xs_cache[name] = xs_objs[0]
         return xs_objs[0]
 
+
     def _ems_available(self):
         """
         Returns True if the EMS is (likely) available and the auto_register CFG entry is True.
@@ -250,11 +251,13 @@ class ExchangeManager(object):
         """
         if CFG.get_safe('container.exchange.auto_register', False) and self.use_ems:
             # ok now make sure it's in the directory
-            service_list, _ = self._rr.find_resources(restype="Service", name='exchange_management')
-            if service_list is not None and len(service_list) > 0:
+            exchange_service = get_service_registry().is_service_available('exchange_management')
+            if exchange_service:
                 return True
 
-        return False
+            return False
+
+
 
     def _bootstrap_default_org(self):
         """
@@ -274,6 +277,8 @@ class ExchangeManager(object):
             log.debug("Bootstrapped Container exchange manager with org id: %s", self.org_id)
 
         return self.org_id
+
+
 
     @property
     def _rr(self):


### PR DESCRIPTION
This utilizes the new status field added by the CEI HA Agent to show the status of the service based on the availability of a worker process. This is intended to fix the timeouts seen in the integration tests that use multiple containers that occur when the policy service is not fully available.
