### PR TITLE
removes special case of read_mult on [ ] by simply returning [ ]

### DIFF
--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -296,6 +296,7 @@ class CouchDB_DataStore(DataStore):
         return obj_list
 
     def read_doc_mult(self, object_ids, datastore_name=""):
+        if not object_ids: return []
         ds, datastore_name = self._get_datastore(datastore_name)
         log.debug('Reading head version of objects %s/%s' % (datastore_name, object_ids))
         docs = ds.view("_all_docs", keys=object_ids, include_docs=True)

--- a/pyon/ion/resregistry.py
+++ b/pyon/ion/resregistry.py
@@ -108,7 +108,7 @@ class ResourceRegistry(object):
         return self.rr_store.read(object_id, rev_id)
 
     def read_mult(self, object_ids=None):
-        if not object_ids:
+        if object_ids is None:
             raise BadRequest("The object_ids parameter is empty")
         return self.rr_store.read_mult(object_ids)
 

--- a/pyon/ion/resregistry_standalone.py
+++ b/pyon/ion/resregistry_standalone.py
@@ -64,7 +64,7 @@ class ResourceRegistryStandalone(object):
         return self.datastore.read_doc(object_id, rev_id)
 
     def read_mult(self, object_ids=None):
-        if not object_ids:
+        if object_ids is None:
             raise BadRequest("The object_ids parameter is empty")
         return self.datastore.read_doc_mult(object_ids)
 


### PR DESCRIPTION
This is NOT UNIT TESTED but works in practice.

This commit removes a special case in read_mult -- for any number of resource_ids, read_mult returns that number of resources.  Previous behavior was to raise an error if 0 resource_ids were supplied.  The previous behavior seems sensible, unless you consider cases where a search algorithm might gather some list of resource_ids then want to convert them all to resources.

The new behavior makes option A equivalent to option B, which is what you'd expect:

``` python

resource_ids = find_some_resource_ids()

#option A

resource_objs = resource_registry_client.read_mult(resource_ids)

#option B

resource_objs = [resource_registry_client.read(r) for r in resource_ids]

```
