### PR TITLE
Print greenlets on USR2

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -23,6 +23,7 @@ from pyon.util.file_sys import FileSystem
 from pyon.util.log import log
 from pyon.util.sflow import SFlowManager
 from pyon.util.context import LocalContextMixin
+from pyon.util.greenlet_plugin import GreenletLeak
 
 from interface.objects import ContainerStateEnum
 from interface.services.icontainer_agent import BaseContainerAgent
@@ -32,6 +33,8 @@ import msgpack
 import os
 import signal
 import traceback
+import sys
+import gevent
 from contextlib import contextmanager
 
 
@@ -140,6 +143,9 @@ class Container(BaseContainerAgent):
                 os.kill(os.getpid(), signal.SIGTERM)
         self._normal_signal = signal.signal(signal.SIGTERM, handl)
 
+        # set up greenlet debugging signal handler
+        gevent.signal(signal.SIGUSR2, self._handle_sigusr2)
+
         self.datastore_manager.start()
         self._capabilities.append("DATASTORE_MANAGER")
 
@@ -204,6 +210,41 @@ class Container(BaseContainerAgent):
         self._status        = "RUNNING"
 
         log.info("Container (%s) started, OK." , self.id)
+
+    def _handle_sigusr2(self):#, signum, frame):
+        """
+        Handles SIGUSR2, prints debugging greenlet information.
+        """
+        gls = GreenletLeak.get_greenlets()
+
+        allgls = []
+
+        for gl in gls:
+            status = GreenletLeak.format_greenlet(gl)
+
+            # build formatted output:
+            # Greenlet at 0xdeadbeef
+            #     self: <EndpointUnit at 0x1ffcceef>
+            #     func: bound, EndpointUnit.some_func
+
+            status[0].insert(0, "%s at %s:" % (gl.__class__.__name__, hex(id(gl))))
+            # indent anything in status a second time
+            prefmt = [s.replace("\t", "\t\t") for s in status[0]]
+            prefmt.append("traceback:")
+
+            for line in status[1]:
+                for subline in line.split("\n")[0:2]:
+                    prefmt.append(subline)
+
+            glstr = "\n\t".join(prefmt)
+
+            allgls.append(glstr)
+
+        # print it out!
+        print >>sys.stderr, "\n\n".join(allgls)
+        with open("gls-%s" % os.getpid(), "w") as f:
+            f.write("\n\n".join(allgls))
+
 
     @property
     def node(self):

--- a/pyon/event/event.py
+++ b/pyon/event/event.py
@@ -222,7 +222,7 @@ class EventSubscriber(Subscriber, BaseEventSubscriberMixin):
         log.info("EventSubscriber stopped. Event pattern=%s" % self.binding)
 
     def __str__(self):
-        return "EventSubscriber: recv_name: %s, cb: %s" % (str(self._recv_name), str(self._callback))
+        return "EventSubscriber at %s:\n\trecv_name: %s\n\tcb: %s" % (hex(id(self)), str(self._recv_name), str(self._callback))
 
 class EventRepository(object):
     """

--- a/pyon/ion/endpoint.py
+++ b/pyon/ion/endpoint.py
@@ -284,7 +284,7 @@ class ProcessRPCServer(RPCServer):
         return RPCServer.create_endpoint(self, **newkwargs)
 
     def __str__(self):
-        return "ProcessRPCServer: recv_name: %s, process: %s" % (str(self._recv_name), str(self._process))
+        return "ProcessRPCServer at %s:\n\trecv_name: %s\n\tprocess: %s" % (hex(id(self)), str(self._recv_name), str(self._process))
 
 class ProcessPublisherEndpointUnit(ProcessEndpointUnitMixin, PublisherEndpointUnit):
     def __init__(self, process=None, **kwargs):
@@ -401,7 +401,7 @@ class ProcessSubscriber(Subscriber):
         return Subscriber.create_endpoint(self, **newkwargs)
 
     def __str__(self):
-        return "ProcessSubscriber: recv_name: %s, process: %s, cb: %s" % (str(self._recv_name), str(self._process), str(self._callback))
+        return "ProcessSubscriber at %s:\n\trecv_name: %s\n\tprocess: %s\n\tcb: %s" % (hex(id(self)), str(self._recv_name), str(self._process), str(self._callback))
 
 
 #
@@ -419,5 +419,5 @@ class ProcessEventSubscriber(ProcessSubscriber, BaseEventSubscriberMixin):
         ProcessSubscriber.__init__(self, from_name=self._ev_recv_name, binding=self.binding, callback=callback, process=process, routing_call=routing_call, **kwargs)
 
     def __str__(self):
-        return "ProcessEventSubscriber: recv_name: %s, process: %s, cb: %s" % (str(self._recv_name), str(self._process), str(self._callback))
+        return "ProcessEventSubscriber at %s:\n\trecv_name: %s\n\tprocess: %s\n\tcb: %s" % (hex(id(self)), str(self._recv_name), str(self._process), str(self._callback))
 

--- a/pyon/util/greenlet_plugin.py
+++ b/pyon/util/greenlet_plugin.py
@@ -25,7 +25,8 @@ class GreenletLeak(Plugin):
     def begin(self):
         self._gls_by_test = {}
 
-    def _get_greenlets(self):
+    @classmethod
+    def get_greenlets(cls):
         """
         Gets a list of all greenlets the gc interface knows about.
 
@@ -34,16 +35,50 @@ class GreenletLeak(Plugin):
         return { obj for obj in gc.get_objects() if isinstance(obj, greenlet) and not obj.dead }
 
     def beforeTest(self, test):
-        self._pre_gls = self._get_greenlets()
+        self._pre_gls = self.get_greenlets()
 
     def afterTest(self, test):
-        post_gls = self._get_greenlets()
+        post_gls = self.get_greenlets()
 
         gls_added = post_gls.difference(self._pre_gls)
         gls_deleted = self._pre_gls.difference(post_gls)
 
         if len(gls_added) > 0:
             self._gls_by_test[test.id()] = gls_added
+
+    @classmethod
+    def format_greenlet(cls, gl):
+        """
+        Returns a tuple of [status/self/func] and stack if applicable.
+        """
+        if gl.dead:
+            return (["    (dead)"], [])
+        else:
+            selfstr = "(unknown)"
+            funcstr = "(unknown)"
+            if hasattr(gl, "_run"):
+                boundstr = "unbound"
+                if hasattr(gl._run, 'im_self'):
+                    selfstr = str(gl._run.im_self)
+                    boundstr = "bound"
+
+                try:
+                    if hasattr(gl._run, 'im_func'):
+                        funcstr = "%s, %s.%s" % (boundstr, gl._run.im_class.__name__, gl._run.im_func.__name__)
+                    elif hasattr(gl._run, 'func_name'):
+                        funcstr = "%s, %s" % (boundstr, func_name)
+
+                except Exception as ex:
+                    #print "WHAT HAPPEN", ex
+                    pass
+
+            selfstr = "self: " + selfstr
+            funcstr = "func: " + funcstr
+
+            # greenlet traceback (maybe interesting)
+            gltb = traceback.format_stack(gl.gr_frame)
+
+            return ([selfstr, funcstr], gltb)
 
     def report(self, stream):
         table = []
@@ -58,21 +93,11 @@ class GreenletLeak(Plugin):
             table.append([ptid, str(gls[0])])
 
             def append_gl_status(gl):
-                if gl.dead:
-                    table.append(["", "    (dead)"])
-                else:
-                    # self of method greenlet is running (hopefully __repr__ is defined)
-                    selfstr = "(none)"
-                    if hasattr(gl._run, 'im_self'):
-                        selfstr = str(gl._run.im_self)
-                    table.append(["", "self: " + selfstr])
-
-                    # greenlet traceback (maybe interesting)
-                    gltb = traceback.format_stack(gl.gr_frame)
-
-                    for line in gltb:
-                        for subline in line.split("\n")[0:2]:
-                            table.append(["", "   " + subline])
+                status = self.format_greenlet(gl)
+                table.append(["", "\n".join(status[0])])
+                for line in status[1]:
+                    for subline in line.split("\n")[0:2]:
+                        table.append(["", "   " + subline])
 
             append_gl_status(gls[0])
             table.append(["", ""])

--- a/scripts/pycc.py
+++ b/scripts/pycc.py
@@ -309,6 +309,7 @@ def main(opts, *args, **kwargs):
         import gevent   # should be auto-monkey-patched by pyon already.
         import select
         import sys
+        import os
         def stdin_ready():
             infds, outfds, erfds = select.select([sys.stdin], [], [], 0)
             if infds:
@@ -352,7 +353,7 @@ def main(opts, *args, **kwargs):
             /____/""",
             exit_msg = 'Leaving ION shell, shutting down container.')
 
-        ipshell('Pyon - ION R2 CC interactive IPython shell. Type ionhelp() for help')
+        ipshell('Pyon (PID: %s) - ION R2 CC interactive IPython shell. Type ionhelp() for help' % os.getpid())
 
     def setup_ipython_embed(shell_api=None):
         from gevent_zeromq import monkey_patch


### PR DESCRIPTION
Prints to stderr (if possible) and to a file, `gls-<pid>`.  When the `-n` option is specified, embedded ipython does not allow printing to stdout/stderr.

Report sample output:

```
Greenlet at 0x103ff7c30:
    self: ProcessRPCServer at 0x104010750:
        recv_name: NP (dd,ASA-DEVELOPERs-MacBook-Pro_local_12376.1,B: ASA-DEVELOPERs-MacBook-Pro_local_12376.1)
        process: HelloService(name=hello,id=ASA-DEVELOPERs-MacBook-Pro_local_12376.1,type=service)
    func: bound, ProcessRPCServer.listen
    traceback:
      File "/Users/asadeveloper/Documents/Dev/code/pyon/eggs/gevent-0.13.7-py2.7-macosx-10.6-x86_64.egg/gevent/greenlet.py", line 390, in run
        result = self._run(*self.args, **self.kwargs)
      File "/Users/asadeveloper/Documents/Dev/code/pyon/pyon/net/endpoint.py", line 486, in listen
        m = self.get_one_msg()
      File "/Users/asadeveloper/Documents/Dev/code/pyon/pyon/net/endpoint.py", line 585, in get_one_msg
        mos = self._get_n_msgs(num=1, timeout=timeout)
      File "/Users/asadeveloper/Documents/Dev/code/pyon/pyon/net/endpoint.py", line 557, in _get_n_msgs
        newch = self._chan.accept(n=num, timeout=timeout)
      File "/Users/asadeveloper/Documents/Dev/code/pyon/pyon/net/channel.py", line 924, in accept
        ar.get(timeout=timeout)
      File "/Users/asadeveloper/Documents/Dev/code/pyon/eggs/gevent-0.13.7-py2.7-macosx-10.6-x86_64.egg/gevent/event.py", line 214, in get
        result = get_hub().switch()
      File "/Users/asadeveloper/Documents/Dev/code/pyon/eggs/gevent-0.13.7-py2.7-macosx-10.6-x86_64.egg/gevent/hub.py", line 164, in switch
        return greenlet.switch(self)

Greenlet at 0x103b43190:
    self: <pyon.ion.process.IonProcessThreadManager object at 0x103afded0>
    func: bound, IonProcessThreadManager.target
    traceback:
      File "/Users/asadeveloper/Documents/Dev/code/pyon/eggs/gevent-0.13.7-py2.7-macosx-10.6-x86_64.egg/gevent/greenlet.py", line 390, in run
        result = self._run(*self.args, **self.kwargs)
      File "/Users/asadeveloper/Documents/Dev/code/pyon/pyon/core/thread.py", line 296, in target
        self._shutdown_event.wait(timeout=self.heartbeat_secs)
      File "/Users/asadeveloper/Documents/Dev/code/pyon/eggs/gevent-0.13.7-py2.7-macosx-10.6-x86_64.egg/gevent/event.py", line 255, in wait
        result = get_hub().switch()
      File "/Users/asadeveloper/Documents/Dev/code/pyon/eggs/gevent-0.13.7-py2.7-macosx-10.6-x86_64.egg/gevent/hub.py", line 164, in switch
        return greenlet.switch(self)
```
