### PR TITLE
Test the conversation monitor catches duplicate messages 

### DIFF
--- a/pyon/ion/test/test_conversation.py
+++ b/pyon/ion/test/test_conversation.py
@@ -11,8 +11,7 @@ from pyon.util.int_test import IonIntegrationTestCase
 from pyon.core.exception import Inconsistent
 from nose.plugins.attrib import attr
 from pyon.service.service import BaseService
-from pyon.net.endpoint import RPCClient
-from pyon.net.channel import BidirClientChannel
+from pyon.net.endpoint import RPCClient, BidirectionalEndpointUnit
 from pyon.util.context import LocalContextMixin
 
 @attr('UNIT')
@@ -144,7 +143,7 @@ class TestConversationInterceptor(IonIntegrationTestCase):
         '''
 
         # save off old send
-        old_send = BidirClientChannel._send
+        old_send = BidirectionalEndpointUnit._send
 
         # make new send to patch on that duplicates send
         def new_send(*args, **kwargs):
@@ -159,12 +158,9 @@ class TestConversationInterceptor(IonIntegrationTestCase):
 
         # patch it into place with auto-cleanup to send a duplicate message at the channel layer which
         #is below the interceptors
-        patcher = patch('pyon.net.channel.BidirClientChannel._send', new_send)
+        patcher = patch('pyon.net.endpoint.BidirectionalEndpointUnit._send', new_send)
         patcher.start()
         self.addCleanup(patcher.stop)
-
-
-
 
         #Should throw an exception by intentionally forcing the message to be sent twice.
         #This is not allowed.

--- a/pyon/ion/test/test_conversation.py
+++ b/pyon/ion/test/test_conversation.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pyon.core.governance.governance_dispatcher import GovernanceDispatcher
 
 __author__ = 'Stephen Henrie'
 __license__ = 'Apache 2.0'
@@ -122,28 +123,18 @@ class TestConversationInterceptor(IonIntegrationTestCase):
 
     def test_interceptor_fails_when_send_multiple_messages(self):
 
-        '''
-        # save off old send
-        old_message_send = RPCRequesterEndpointUnit._message_send
-
-        # make new send to patch on that duplicates send
-        def new_message_send(*args, **kwargs):
-            print 'In the patched new_message_send'
-
-            #Only duplicate the message send from the initial client
-            if args[0]._endpoint._process.name != 'conv_test':
-                old_message_send(*args, **kwargs)
-
-            return old_message_send(*args, **kwargs)
-
-        # patch it into place with auto-cleanup
-        patcher = patch('pyon.ion.conversation.RPCRequesterEndpointUnit._message_send', new_message_send)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        '''
 
         # save off old send
         old_send = BidirectionalEndpointUnit._send
+
+        class WrongMessageAssertion(Exception):
+            pass
+
+        def handle_outgoing_message(*args, **kwargs):
+            inv  = args[1]
+            if inv.message_annotations.has_key(GovernanceDispatcher.CONVERSATION__STATUS_ANNOTATION) and\
+               inv.message_annotations[GovernanceDispatcher.CONVERSATION__STATUS_ANNOTATION] == GovernanceDispatcher.STATUS_REJECT:
+                    raise WrongMessageAssertion("Monitor detected an error")
 
         # make new send to patch on that duplicates send
         def new_send(*args, **kwargs):
@@ -162,12 +153,16 @@ class TestConversationInterceptor(IonIntegrationTestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
+
+        patcher = patch('pyon.core.governance.governance_dispatcher.GovernanceDispatcher.handle_outgoing_message',
+                        handle_outgoing_message)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
         #Should throw an exception by intentionally forcing the message to be sent twice.
         #This is not allowed.
-        ret = self.provider_client.request({'text': 'hello world'}, op='reverse_string' )
-
-        #Check to see if the text has been reversed.
-        self.assertEqual(ret,'dlrow olleh')
+        self.assertRaises(WrongMessageAssertion, self.provider_client.request,
+                            {'text': 'hello world'}, op='reverse_string')
 
     '''
 


### PR DESCRIPTION
This patch provides a fix to the test_interceptor_fails_when_send_multiple_messages so the test can check weather the conversation monitor detects a wrong sequence of messages:  2 consecutive request messages with the same conversation id. The test patches the send method of the BidirectionalEndpointUnit class.
