### PR TITLE
Container fail_fast when messaging fails a connection

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -417,12 +417,13 @@ class Container(BaseContainerAgent):
         else:
             raise ContainerError("Cannot stop capability: %s" % capability)
 
-    def fail_fast(self, err_msg=""):
+    def fail_fast(self, err_msg="", skip_stop=False):
         """
         Container needs to shut down and NOW.
         """
         log.error("Fail Fast: %s", err_msg)
-        self.stop()
+        if not skip_stop:
+            self.stop()
         log.error("Fail Fast: killing container")
 
         traceback.print_exc()

--- a/pyon/container/test/test_cc.py
+++ b/pyon/container/test/test_cc.py
@@ -29,6 +29,13 @@ class TestCC(PyonTestCase):
         self.cc.stop.assert_called_once_with()
         osmock.kill.assert_called_once_with(osmock.getpid(), signal.SIGTERM)
 
+    @patch('pyon.container.cc.os')
+    def test_fail_fast_no_stop(self, osmock):
+        self.cc.stop = Mock()
+
+        self.cc.fail_fast("icecream (of the future)", True)
+        self.assertEquals(self.cc.stop.call_count, 0)
+
     def test_node_when_not_started(self):
         self.assertEquals(self.cc.node, None)
 

--- a/pyon/net/messaging.py
+++ b/pyon/net/messaging.py
@@ -20,6 +20,7 @@ from pyon.util.pool import IDPool
 from pyon.net.transport import LocalTransport, LocalRouter, AMQPTransport, ComposableTransport
 
 from collections import defaultdict
+import traceback
 
 class BaseNode(object):
     """
@@ -174,8 +175,10 @@ class NodeB(BaseNode):
         amq_chan = blocking_cb(self.client.channel, 'on_open_callback', channel_number=ch_number)
         if amq_chan is None:
             log.error("AMQCHAN IS NONE THIS SHOULD NEVER HAPPEN, chan number requested: %s", ch_number)
-            import traceback
             traceback.print_stack()
+            from pyon.container.cc import Container
+            if Container.instance is not None:
+                Container.instance.fail_fast("AMQCHAN IS NONE, messaging has failed", True)
             raise StandardError("AMQCHAN IS NONE THIS SHOULD NEVER HAPPEN, chan number requested: %s" % ch_number)
 
         transport = AMQPTransport(amq_chan)

--- a/pyon/net/test/test_messaging.py
+++ b/pyon/net/test/test_messaging.py
@@ -222,6 +222,21 @@ class TestNodeB(PyonTestCase):
 
         self.assertEqual(chmock._destroy_queue.call_count, 20)
 
+    @patch('pyon.net.messaging.blocking_cb')
+    def test__new_transport(self, bcbmock):
+        self._node.client = Mock()
+        transport = self._node._new_transport()
+
+        bcbmock.assert_called_once_with(self._node.client.channel, 'on_open_callback', channel_number=None)
+
+    @patch('pyon.net.messaging.traceback', Mock())
+    @patch('pyon.net.messaging.blocking_cb', return_value=None)
+    @patch('pyon.container.cc.Container.instance')
+    def test__new_transport_fails(self, containermock, bcbmock):
+        self._node.client = Mock()
+        self.assertRaises(StandardError, self._node._new_transport)
+        containermock.fail_fast.assert_called_once_with("AMQCHAN IS NONE, messaging has failed", True)
+
 @attr('UNIT')
 class TestMessaging(PyonTestCase):
     def test_ioloop(self):


### PR DESCRIPTION
Fixes OOIION-656.  Will abort the `stop` call as with messaging, we can't effectively do this.  Need to make more robust with a dead connection.
