### PR TITLE
OOIION-614: add ionobject parameter to EventPublisher:publish_event meth...

### DIFF
--- a/pyon/event/event.py
+++ b/pyon/event/event.py
@@ -67,14 +67,15 @@ class EventPublisher(Publisher):
         routing_key = "%s.%s.%s.%s.%s" % (base_str, event_type, sub_type, origin_type, origin)
         return routing_key
 
-    def _create_event(self, event_type=None, **kwargs):
-        event_type = event_type or self.event_type
-        assert event_type
+    def _create_event(self, event_type=None, ionobject=None, **kwargs):
+        if ionobject is None:
+            event_type = event_type or self.event_type
+            assert event_type
 
-        if 'ts_created' not in kwargs:
-            kwargs['ts_created'] = get_ion_ts()
+            if 'ts_created' not in kwargs:
+                kwargs['ts_created'] = get_ion_ts()
 
-        event_msg = bootstrap.IonObject(event_type, **kwargs)
+            event_msg = bootstrap.IonObject(event_type, **kwargs)
         event_msg.base_types = event_msg._get_extends()
 
         # Would like to validate here but blows up if an object is provided where a dict is declared
@@ -107,7 +108,7 @@ class EventPublisher(Publisher):
 
         return True
 
-    def publish_event(self, origin=None, event_type=None, **kwargs):
+    def publish_event(self, origin=None, event_type=None, ionobject=None, **kwargs):
         """
         Publishes an event of given type for the given origin. Event_type defaults to an
         event_type set when initializing the EventPublisher. Other kwargs fill out the fields
@@ -118,7 +119,7 @@ class EventPublisher(Publisher):
         @param kwargs     additional event fields
         @retval  bool  indicating success of this operation
         """
-        event_msg = self._create_event(origin=origin, event_type=event_type, **kwargs)
+        event_msg = self._create_event(origin=origin, event_type=event_type, ionobject=ionobject, **kwargs)
         success = self._publish_event(event_msg, origin=origin)
         return success
 


### PR DESCRIPTION
EventPublisher:publish_event basically creates ionobject using _create_event; since the request is to add an ionobject parameter the fix simply checks whether ionobject is passed and if so bypasses most of the ionbject creation part in _create_event
