### PR TITLE
Add auto_delete to EventSubscriber initializer (OOIION-676)

### DIFF
--- a/pyon/event/event.py
+++ b/pyon/event/event.py
@@ -188,7 +188,7 @@ class EventSubscriber(Subscriber, BaseEventSubscriberMixin):
     ALL_EVENTS = "#"
 
     def __init__(self, xp_name=None, event_type=None, origin=None, queue_name=None, callback=None,
-                 sub_type=None, origin_type=None, pattern=None, *args, **kwargs):
+                 sub_type=None, origin_type=None, pattern=None, auto_delete=None, *args, **kwargs):
         """
         Initializer.
 
@@ -199,6 +199,7 @@ class EventSubscriber(Subscriber, BaseEventSubscriberMixin):
         Note: an EventSubscriber needs to be closed to free broker resources
         """
         self._cbthread = None
+        self._auto_delete = auto_delete
 
         BaseEventSubscriberMixin.__init__(self, xp_name=xp_name, event_type=event_type, origin=origin,
                                           queue_name=queue_name, sub_type=sub_type, origin_type=origin_type, pattern=pattern)
@@ -228,6 +229,16 @@ class EventSubscriber(Subscriber, BaseEventSubscriberMixin):
 
     def __str__(self):
         return "EventSubscriber at %s:\n\trecv_name: %s\n\tcb: %s" % (hex(id(self)), str(self._recv_name), str(self._callback))
+
+    def _create_channel(self, **kwargs):
+        """
+        Override to set the channel's queue_auto_delete property.
+        """
+        ch = Subscriber._create_channel(self, **kwargs)
+        if self._auto_delete is not None:
+            ch.queue_auto_delete = self._auto_delete
+
+        return ch
 
 class EventRepository(object):
     """

--- a/pyon/event/test/test_event.py
+++ b/pyon/event/test/test_event.py
@@ -24,9 +24,21 @@ from interface.objects import Event, ResourceLifecycleEvent
 
 from pyon.core.exception import FilesystemError, StreamingError, CorruptionError
 
+@attr('UNIT',group='event')
+class TestEvents(IonUnitTestCase):
+    def test_event_subscriber_auto_delete(self):
+        mocknode = Mock()
+        ev = EventSubscriber(event_type="ProcessLifecycleEvent", callback=lambda *a,**kw: None, auto_delete=sentinel.auto_delete, node=mocknode)
+        self.assertEquals(ev._auto_delete, sentinel.auto_delete)
+
+        # we don't want to have to patch out everything here, so call initialize directly, which calls create_channel for us
+        ev._setup_listener = Mock()
+        ev.initialize(sentinel.binding)
+
+        self.assertEquals(ev._chan.queue_auto_delete, sentinel.auto_delete)
 
 @attr('INT',group='event')
-class TestEvents(IonIntegrationTestCase):
+class TestEventsInt(IonIntegrationTestCase):
 
     def setUp(self):
         self._listens = []

--- a/pyon/ion/endpoint.py
+++ b/pyon/ion/endpoint.py
@@ -411,7 +411,9 @@ class ProcessSubscriber(Subscriber):
 #
 class ProcessEventSubscriber(ProcessSubscriber, BaseEventSubscriberMixin):
     def __init__(self, xp_name=None, event_type=None, origin=None, queue_name=None, callback=None,
-                 sub_type=None, origin_type=None, process=None, routing_call=None, *args, **kwargs):
+                 sub_type=None, origin_type=None, process=None, routing_call=None, auto_delete=None, *args, **kwargs):
+
+        self._auto_delete = auto_delete
 
         BaseEventSubscriberMixin.__init__(self, xp_name=xp_name, event_type=event_type, origin=origin,
                                           queue_name=queue_name, sub_type=sub_type, origin_type=origin_type)
@@ -422,4 +424,14 @@ class ProcessEventSubscriber(ProcessSubscriber, BaseEventSubscriberMixin):
 
     def __str__(self):
         return "ProcessEventSubscriber at %s:\n\trecv_name: %s\n\tprocess: %s\n\tcb: %s" % (hex(id(self)), str(self._recv_name), str(self._process), str(self._callback))
+
+    def _create_channel(self, **kwargs):
+        """
+        Override to set the channel's queue_auto_delete property.
+        """
+        ch = ProcessSubscriber._create_channel(self, **kwargs)
+        if self._auto_delete is not None:
+            ch.queue_auto_delete = self._auto_delete
+
+        return ch
 

--- a/pyon/net/endpoint.py
+++ b/pyon/net/endpoint.py
@@ -506,17 +506,12 @@ class ListeningBaseEndpoint(BaseEndpoint):
         """
         Creates a channel and prepares it for use.
 
-        After this, the endpoint is inthe ready state.
+        After this, the endpoint is in the ready state.
         """
         binding = binding or self._binding or self._recv_name.binding
 
         self._ensure_node()
-        kwargs = {}
-        if isinstance(self._recv_name, BaseTransport):
-            kwargs.update({'transport': self._recv_name})
-        elif self._transport is not None:
-            kwargs.update({'transport': self._transport})
-        self._chan = self.node.channel(self.channel_type, **kwargs)
+        self._chan = self._create_channel()
 
         # @TODO this does not feel right
         if isinstance(self._recv_name, BaseTransport):


### PR DESCRIPTION
Adds the ability to pass auto_delete up to the channel creation for a listening `EventSubscriber`/`ProcessEventSubscriber`.

In the case of a clean shutdown, this is redundant: the `SubscriberChannel` close already will delete any anonymous queues (given it meets a long list of conditions), but the auto_delete flag here will handle non-graceful shutdowns.  See https://github.com/ooici/pyon/blob/master/pyon/net/channel.py#L954-L957 for implementation details on the Subscriber's deletion mechanism.
