### PR TITLE
increase coverage in PDP, fix problem in FSM tests, minor update in PDP

### DIFF
--- a/pyon/core/governance/conversation/core/test/test_fsm.py
+++ b/pyon/core/governance/conversation/core/test/test_fsm.py
@@ -13,7 +13,7 @@ def dummy_action(fsm):
 def toDeque(alist):
     return [deque(l) for l in alist]
 
-attr('UNIT')
+@attr('UNIT')
 class TestFSM(PyonTestCase):
     def get_test_fsm(self):
         # build test data

--- a/pyon/core/governance/conversation/test/test_fsm_processing.py
+++ b/pyon/core/governance/conversation/test/test_fsm_processing.py
@@ -85,7 +85,7 @@ def recAsRepeat_events():
     events.append(TransitionFactory.create(LocalType.SEND, 'OK', 'Seller'))
     return events
 
-attr('INT')
+@attr('INT')
 class TestFSM(IonIntegrationTestCase):
     def setUp(self):
         cur_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))

--- a/pyon/core/governance/policy/policy_decision.py
+++ b/pyon/core/governance/policy/policy_decision.py
@@ -237,26 +237,28 @@ class PolicyDecisionPointManager(object):
         if not process:
             raise NotFound('Cannot find process in message')
 
-        receiver = invocation.get_message_receiver()
+        decision = self._check_service_request_policies(invocation, 'agent')
 
-        decision = self._check_service_request_policies(invocation, receiver, 'agent')
-
-        #Return if agent service policies deny the operation
+        # todo: check if its OK to treat everything but Deny as Permit (Ex: NotApplicable)
+        # Return if agent service policies deny the operation
         if decision == Decision.DENY_STR:
             return decision
 
-        #Else check any policies that might be associated with the resource.
+        # Else check any policies that might be associated with the resource.
         decision = self.check_resource_request_policies(invocation, process.resource_id)
 
         return decision
 
     def check_service_request_policies(self, invocation):
-        receiver = invocation.get_message_receiver()
-
-        decision = self._check_service_request_policies(invocation, receiver, 'service')
+        decision = self._check_service_request_policies(invocation, 'service')
         return decision
 
-    def _check_service_request_policies(self, invocation, receiver, receiver_type):
+    def _check_service_request_policies(self, invocation, receiver_type):
+
+        receiver = invocation.get_message_receiver()
+
+        if not receiver:
+            raise NotFound('No receiver for this message')
 
         requestCtx = self._create_request_from_message(invocation, receiver, receiver_type)
 

--- a/pyon/core/governance/policy/test/test_policy_decision.py
+++ b/pyon/core/governance/policy/test/test_policy_decision.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+
+__author__ = 'Prashant Kediyal'
+
+from nose.plugins.attrib import attr
+from mock import Mock
+import unittest
+from pyon.core.governance.policy.policy_decision import PolicyDecisionPointManager
+from pyon.core.exception import NotFound
+
+
+@attr('UNIT')
+class PolicyDecisionUnitTest(unittest.TestCase):
+
+    permit_ION_MANAGER_rule = '''
+        <Rule RuleId="%s:" Effect="Permit">
+            <Description>
+                %s
+            </Description>
+
+
+        <Target>
+            <Subjects>
+                <Subject>
+                    <SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ION_MANAGER</AttributeValue>
+                        <SubjectAttributeDesignator
+                             AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-role-id"
+                             DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                    </SubjectMatch>
+                </Subject>
+            </Subjects>
+        </Target>
+
+
+        </Rule>
+        '''
+
+    deny_ION_MANAGER_rule = '''
+        <Rule RuleId="%s:" Effect="Deny">
+            <Description>
+                %s
+            </Description>
+
+
+        <Target>
+            <Subjects>
+                <Subject>
+                    <SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ION_MANAGER</AttributeValue>
+                        <SubjectAttributeDesignator
+                             AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-role-id"
+                             DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                    </SubjectMatch>
+                </Subject>
+            </Subjects>
+        </Target>
+
+
+        </Rule>
+        '''
+
+    def test_resource_policies(self):
+        gc = Mock()
+        resource_id = 'resource_key'
+        pdpm = PolicyDecisionPointManager(gc)
+        # see that the PDP for resource is empty
+        self.assertEqual(pdpm.get_resource_pdp(resource_id), pdpm.empty_pdp)
+
+        pdpm.load_resource_policy_rules(resource_id, self.permit_ION_MANAGER_rule)
+
+        # see that the PDP for resource is not empty anymore
+        self.assertNotEqual(pdpm.get_resource_pdp(resource_id), pdpm.empty_pdp)
+
+        # check request without a resource_id raises NotFound error
+        self.invocation = Mock()
+        with self.assertRaises(NotFound) as chk_res:
+            pdpm.check_resource_request_policies(self.invocation, None)
+        self.assertIn(chk_res.exception.message, 'The resource_id is not set')
+
+        # check that, because actor does not have ION_MANAGER role, policy evaluates to a denial
+        # (really Not Applicable, because of the inelegant hack of a policy we are setting up our pdp with)
+        mock_header = Mock()
+        self.invocation.headers = {'op': 'op', 'process': 'process', 'request': 'request', 'ion-actor-id': 'ion-actor-id', 'receiver': 'resource-registry',
+                                   'sender-type': 'sender-type', 'sender-service': 'sender-service', 'ion-actor-roles': {'org_name': ['ion-actor-roles']}}
+
+        def get_header_value(key, default):
+            return self.invocation.headers.get(key, default)
+        mock_header.side_effect = get_header_value
+        self.invocation.get_header_value = mock_header
+        mock_args = Mock()
+        process = Mock()
+        process.org_name = 'org_name'
+        self.invocation.args = {'process': process}
+
+        def get_arg_value(key, default):
+            return self.invocation.args.get(key, default)
+        mock_args.side_effect = get_arg_value
+        self.invocation.get_arg_value = mock_args
+
+        gc._system_root_org_name = 'sys_org_name'
+
+        response = pdpm.check_resource_request_policies(self.invocation, resource_id)
+        self.assertEqual(response.value, "NotApplicable")
+
+        # check that policy evaluates to Permit because actor has ION_MANAGER role
+        self.invocation.headers = {'op': 'op', 'process': 'process', 'request': 'request', 'ion-actor-id': 'ion-actor-id', 'receiver': 'resource-registry',
+                                   'sender-type': 'sender-type', 'sender-service': 'sender-service', 'ion-actor-roles': {'sys_org_name': ['ION_MANAGER']}}
+        response = pdpm.check_resource_request_policies(self.invocation, resource_id)
+        self.assertEqual(response.value, "Permit")
+
+    def test_service_policies(self):
+        gc = Mock()
+        service_key = 'service_key'
+        pdpm = PolicyDecisionPointManager(gc)
+        # see that the PDP for service is the default
+        self.assertEqual(pdpm.get_service_pdp(service_key), pdpm.load_common_service_pdp)
+
+        pdpm.load_service_policy_rules(service_key, self.permit_ION_MANAGER_rule)
+
+        # see that the PDP for service is not the default anymore
+        self.assertNotEqual(pdpm.get_service_pdp(service_key), pdpm.load_common_service_pdp)
+
+        # check request without a service_key raises NotFound error
+        self.invocation = Mock()
+        self.invocation.get_message_receiver.return_value = None
+        with self.assertRaises(NotFound) as chk_res:
+            pdpm.check_service_request_policies(self.invocation)
+        self.assertIn(chk_res.exception.message, 'No receiver for this message')
+
+        # check that, because actor does not have ION_MANAGER role, policy evaluates to a denial
+        # (really Not Applicable, because of the inelegant hack of a policy we are setting up our pdp with)
+        mock_header = Mock()
+        self.invocation.headers = {'op': 'op', 'process': 'process', 'request': 'request', 'ion-actor-id': 'ion-actor-id', 'receiver': 'resource-registry',
+                                   'sender-type': 'sender-type', 'sender-service': 'Unknown', 'ion-actor-roles': {'org_name': ['ion-actor-roles']}}
+        self.invocation.get_message_receiver.return_value = 'service_key'
+        self.invocation.get_service_name.return_value = 'Unknown'
+
+        def get_header_value(key, default):
+            return self.invocation.headers.get(key, default)
+        mock_header.side_effect = get_header_value
+        self.invocation.get_header_value = mock_header
+        mock_args = Mock()
+        process = Mock()
+        process.org_name = 'org_name'
+        self.invocation.args = {'process': process}
+
+        def get_arg_value(key, default):
+            return self.invocation.args.get(key, default)
+        mock_args.side_effect = get_arg_value
+        self.invocation.get_arg_value = mock_args
+
+        gc._system_root_org_name = 'sys_org_name'
+
+        response = pdpm.check_service_request_policies(self.invocation)
+        self.assertEqual(response.value, "NotApplicable")
+
+        # check that policy evaluates to Permit because actor has ION_MANAGER role
+        self.invocation.headers = {'op': 'op', 'process': 'process', 'request': 'request', 'ion-actor-id': 'ion-actor-id', 'receiver': 'resource-registry',
+                                   'sender-type': 'sender-type', 'sender-service': 'sender-service', 'ion-actor-roles': {'sys_org_name': ['ION_MANAGER']}}
+        response = pdpm.check_service_request_policies(self.invocation)
+        self.assertEqual(response.value, "Permit")
+
+    def test_agent_policies(self):
+
+        # set up data
+        gc = Mock()
+        service_key = 'service_key'
+        resource_id = 'resource_id'
+        pdpm = PolicyDecisionPointManager(gc)
+        self.invocation = Mock()
+        mock_header = Mock()
+        self.invocation.headers = {'op': 'op', 'process': 'process', 'request': 'request', 'ion-actor-id': 'ion-actor-id', 'receiver': 'resource-registry',
+                                   'sender-type': 'sender-type', 'sender-service': 'Unknown', 'ion-actor-roles': {'org_name':  ['ION_MANAGER']}}
+        self.invocation.get_message_receiver.return_value = 'service_key'
+        self.invocation.get_service_name.return_value = 'Unknown'
+
+        def get_header_value(key, default):
+            return self.invocation.headers.get(key, default)
+        mock_header.side_effect = get_header_value
+        self.invocation.get_header_value = mock_header
+        mock_args = Mock()
+        process = Mock()
+        process.org_name = 'org_name'
+        process.resource_id = 'resource_id'
+        self.invocation.args = {'process': process}
+
+        def get_arg_value(key, default='Unknown'):
+            return self.invocation.args.get(key, default)
+        mock_args.side_effect = get_arg_value
+        self.invocation.get_arg_value = mock_args
+        gc._system_root_org_name = 'sys_org_name'
+
+        # check that service policies result in denying the request
+        pdpm.load_service_policy_rules(service_key, self.deny_ION_MANAGER_rule)
+        pdpm.load_resource_policy_rules(resource_id, self.permit_ION_MANAGER_rule)
+        response = pdpm.check_agent_request_policies(self.invocation)
+        self.assertEqual(response.value, "Deny")
+
+        # check that resource policies result in denying the request
+        pdpm.load_service_policy_rules(service_key, self.permit_ION_MANAGER_rule)
+        pdpm.load_resource_policy_rules(resource_id, self.deny_ION_MANAGER_rule)
+        response = pdpm.check_agent_request_policies(self.invocation)
+        self.assertEqual(response.value, "Deny")
+
+        # check that both service and resource policies need to allow a request
+        pdpm.load_service_policy_rules(service_key, self.permit_ION_MANAGER_rule)
+        pdpm.load_resource_policy_rules(resource_id, self.permit_ION_MANAGER_rule)
+        response = pdpm.check_agent_request_policies(self.invocation)
+        self.assertEqual(response.value, "Permit")


### PR DESCRIPTION
adds unit tests of policy_decision

rumy's recent FSM tests had a minor problem where she incorrectly declared the decorator without the @ sign, thus attr('INT') instead of @attr('INT')

PDP had minor code redundancy that is now fixed. And it did not handle the rare case where messages arrive without a receiver this has been fixed to check for missing receiver because similar handling is done in the resource_request where there is a check for missing resource_id
