### PR TITLE
work around issue with static import

### DIFF
--- a/pyon/core/log.py
+++ b/pyon/core/log.py
@@ -37,4 +37,4 @@ def configure_logging(logging_conf_paths, logging_config_override=None):
 def is_logging_configured():
     """ allow caller to determine if logging has already been configured in this container """
     global logging_was_configured
-    return logging_was_configured
+    return logging_was_configured or config.get_configuration()


### PR DESCRIPTION
work around static import in unit_test that causes MI tests (that import unit_test) to configure logging twice -- once using normal MI files, and again using coi-services files.
