### PR TITLE
Give tests copy-pastable identifiers in nose testing

### DIFF
--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -45,6 +45,18 @@ class IonIntegrationTestCase(unittest.TestCase):
     def shortDescription(self):
         return None
 
+    # override __str__ and __repr__ behavior to show a copy-pastable nosetest name for ion tests
+    #  ion.module:TestClassName.test_function_name
+    def __repr__(self):
+        name = self.id()
+        name = name.split('.')
+        if name[0] not in ["ion", "pyon"]:
+            return "%s (%s)" % (name[-1], '.'.join(name[:-1]))
+        else:
+            return "%s ( %s )" % (name[-1], '.'.join(name[:-2]) + ":" + '.'.join(name[-2:]))
+    __str__ = __repr__
+
+
     def run(self, result=None):
         unittest.TestCase.run(self, result)
 

--- a/pyon/util/unit_test.py
+++ b/pyon/util/unit_test.py
@@ -35,6 +35,17 @@ class PyonTestCase(unittest.TestCase):
     def shortDescription(self):
         return None
 
+    # override __str__ and __repr__ behavior to show a copy-pastable nosetest name for ion tests
+    #  ion.module:TestClassName.test_function_name
+    def __repr__(self):
+        name = self.id()
+        name = name.split('.')
+        if name[0] not in ["ion", "pyon"]:
+            return "%s (%s)" % (name[-1], '.'.join(name[:-1]))
+        else:
+            return "%s ( %s )" % (name[-1], '.'.join(name[:-2]) + ":" + '.'.join(name[-2:]))
+    __str__ = __repr__
+
     def _create_IonObject_mock(self, name):
         mock_ionobj = Mock(name='IonObject')
         def side_effect(_def, _dict=None, **kwargs):


### PR DESCRIPTION
This patch fixes an annoyance.

Currently, failing nosetests are printed like this

```
======================================================================
FAIL: test_the_name (ion.services.sa.test.test_nosetest_namimg.TestNaming)
----------------------------------------------------------------------
```

This patch prints them like this:

```
======================================================================
FAIL: test_the_name ( ion.services.sa.test.test_nosetest_namimg:TestNaming.test_the_name )
----------------------------------------------------------------------
```

Unlike the current format, "ion.services.sa.test.test_nosetest_namimg:TestNaming.test_the_name" can be pasted directly into the nosetests command line.
