### PR TITLE
Fixes numpy encoding errors

### DIFF
--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -332,15 +332,16 @@ def walk(o, cb):
 
     @TODO move to a general utils area?
     """
+    if _have_numpy and isinstance(o, np.ndarray):
+        return o
     newo = cb(o)
 
     # is now or is still an iterable? iterate it.
-    if _have_numpy:
-        if isinstance(newo, np.ndarray):
-            return newo
     if hasattr(newo, '__iter__'):
         if isinstance(newo, dict):
-            return dict(((k, walk(v, cb)) for k, v in newo.iteritems()))
+            return {k:walk(v,cb) for k,v in newo.iteritems()}
+        elif _have_numpy and isinstance(newo, np.ndarray):
+            return newo
         else:
             return [walk(x, cb) for x in newo]
 

--- a/pyon/core/registry.py
+++ b/pyon/core/registry.py
@@ -7,6 +7,7 @@ import inspect
 from copy import deepcopy
 
 from pyon.core.exception import NotFound
+from pyon.core.object import walk
 
 import interface.objects
 import interface.messages
@@ -146,28 +147,11 @@ class IonObjectRegistry(object):
                 if name not in self._schema and name not in built_in_attrs:
                     raise AttributeError("'%s' object has no attribute '%s'" % (type(self).__name__, name))
 
-                def recursive_encoding(value):
+                def utf8fix(value):
                     if isinstance(value, unicode):
-                        value = str(value.encode('utf8'))
-                    elif hasattr(value, '__iter__'):
-                        if isinstance(value, dict):
-                            remove_key = []
-                            add_key_value = {}
-                            for k, v in value.iteritems():
-                                if isinstance(k, unicode):
-                                    remove_key.append(k)
-                                    k = str(k.encode('utf8'))
-                                    add_key_value[k] = v
-                                if isinstance(v, unicode):
-                                    add_key_value[k] = str(v.encode('utf8'))
-                                elif hasattr(v, '__iter__'):
-                                    add_key_value[k] = recursive_encoding(v)
-                            for k in remove_key:
-                                del value[k]
-                            for k, v in add_key_value.iteritems():
-                                value[k] = v
-                        else:
-                            value = map(recursive_encoding, value)
+                        return str(value.encode('utf8'))
+                def recursive_encoding(value):
+                    walk(value,utf8fix)
                     return value
                 self.__dict__[name] = recursive_encoding(value)
 


### PR DESCRIPTION
I don't even know where to begin describing this bug.

Here is the outgoing granule before encoding

```
{'domain': (10,), 'data_producer_id': '', 'connection_index': '',
'record_dictionary': {1: array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,
8.,  9.]), 2: None, 3: None, 4: None, 5: None, 6: None, 7: None, 8:
None, 9: None, 10: None, 11: None, 12: None, 13: None, 14: None, 15:
None, 16: None, 17: None, 18: None, 19: None}, 'connection_id': '',
'locator': None, 'type_': 'Granule', 'param_dictionary':
'9a1f8b57e7af41479d42ce0764ad4ec1', 'creation_timestamp':
1365446562.004057, 'provider_metadata_update': {}}
```

Here it is after encoding

```
><> {'domain': [10], 'data_producer_id': '', 'connection_index': '',
>'record_dictionary': {1: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
>9.0], 2: None, 3: None, 4: None, 5: None, 6: None, 7: None, 8: None, 9:
>None, 10: None, 11: None, 12: None, 13: None, 14: None, 15: None, 16:
>None, 17: None, 18: None, 19: None}, 'connection_id': '', 'locator':
>None, 'type_': 'Granule', 'param_dictionary':
>'9a1f8b57e7af41479d42ce0764ad4ec1', 'creation_timestamp':
>1365446562.004057, 'provider_metadata_update': {}}
```

The numpy array was converted into a list and it turns out it stemmed
from the IonObject's overloading the setattr which is dynamically
attached at runtime inside registry.py and the walker bypasses walk and
somehow converts the numpy array into a list because numpy has **iter**.

Dave F suggested we use walk here so I implemented it using walk and now
granules flow again without bugs.
