### PR TITLE
modify walk to handle dicts and list instead of all __iter__ ables;

### DIFF
--- a/pyon/core/test/test_object.py
+++ b/pyon/core/test/test_object.py
@@ -171,8 +171,8 @@ class ObjectTest(IonIntegrationTestCase):
         obj.a_dict = a_dict
 
         # check types of the innermost elements
-        type_inner_element = type(a_dict[3][4][1][1])
-        type_remains_str = type(a_dict[6][4][1][1])
+        type_inner_element = type(obj.a_dict[3][4][1][1])
+        type_remains_str = type(obj.a_dict[6][4][1][1])
 
         # check that the type of the first innermost element is now type str
         self.assertEqual(type_inner_element, type_str)
@@ -180,8 +180,7 @@ class ObjectTest(IonIntegrationTestCase):
         self.assertEqual(type_another_element, type_remains_str)
 
         # check that a unicode element did get utf-8 encoded
-        self.assertEqual(a_dict['Four'],'\xe0\xa5\xaa')
-
+        self.assertEqual(obj.a_dict['Four'],'\xe0\xa5\xaa')
 
 
 


### PR DESCRIPTION
Here is a thing Dave/Luke need to give some input on as well. The current solution is different from Luke's in a subtle way.

Earlier, in recursive_encoding the transformation occurred on the reference to the dict that had been passed in. Now, the transformation is of the dict. This means recursive_encoding changes by value not by reference (one has to pardon loose and ambiguous use of terms here because python passes by value but in case for dict the value is the reference). To unambiguously see what I mean notice the changes in the test_object.py included in the commit.

The solution isn't doing something incorrect, but a change is a change in behavior and in this case it happens due to the way walk behaves.

Our tests in coi-services and pyon and Luke's tests pass though, and I don't expect a problem.
