### PR TITLE
Fix OOIION-806/897: Process state fixes and enhancements

### DIFF
--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -656,7 +656,7 @@ class ProcManager(object):
                 if not hasattr(process_instance, "_proc_state"):
                     process_instance._proc_state = {}
                 try:
-                    new_state = process_instance.container.state_repository.get_state(process_instance.id)
+                    new_state, _ = process_instance.container.state_repository.get_state(process_instance.id)
                     process_instance._proc_state.clear()
                     process_instance._proc_state.update(new_state)
                     process_instance._proc_state_changed = False

--- a/pyon/ion/endpoint.py
+++ b/pyon/ion/endpoint.py
@@ -273,8 +273,7 @@ class ProcessRPCResponseEndpointUnit(ProcessEndpointUnitMixin, RPCResponseEndpoi
         if hasattr(self._process, "_proc_state"):
             if self._process._proc_state_changed:
                 log.debug("Process %s state changed. State=%s", self._process.id, self._process._proc_state)
-                self._process.container.state_repository.put_state(self._process.id, self._process._proc_state)
-                self._process._proc_state_changed = False
+                self._process._flush_state()
         return res
 
     def _get_process_saturation(self):

--- a/pyon/ion/state.py
+++ b/pyon/ion/state.py
@@ -6,7 +6,7 @@ __author__ = 'Michael Meisinger'
 __license__ = 'Apache 2.0'
 
 from pyon.core import bootstrap
-from pyon.core.exception import NotFound, BadRequest
+from pyon.core.exception import NotFound, BadRequest, Conflict
 from pyon.datastore.datastore import DataStore
 from pyon.util.containers import get_ion_ts
 from pyon.util.log import log
@@ -39,7 +39,7 @@ class StateRepository(object):
         """
         self.state_store.close()
 
-    def put_state(self, key, state):
+    def put_state(self, key, state, state_obj=None):
         """
         Persist a private process state using the given key (typically a process id).
         The state vector is an object (e.g. a dict) that may contain any python type that
@@ -47,29 +47,46 @@ class StateRepository(object):
         WARNING: If multiple threads/greenlets persist state concurrently, e.g. based
         on message processing and time, the calls to this method need to be protected
         by an exclusive lock (semaphore).
+        @retval the ProcessState object as written
         """
         log.debug("Store persistent state for key=%s", key)
         if not isinstance(state, dict):
             raise BadRequest("state must be type dict, not %s" % type(state))
+        if state_obj is not None:
+            if not isinstance(state_obj, ProcessState):
+                raise BadRequest("Argument state_obj is not ProcessState object")
+            state_obj.state = state
+            state_obj.ts = get_ion_ts()
+            try:
+                id, rev = self.state_store.update(state_obj)
+                state_obj._rev = rev
+                return state_obj
+            except Conflict as ce:
+                log.info("Process %s state update conflict - retry.")
+
         try:
             state_obj = self.state_store.read(key)
             state_obj.state = state
             state_obj.ts = get_ion_ts()
-            self.state_store.update(state_obj)
+            id, rev = self.state_store.update(state_obj)
+            state_obj._rev = rev
         except NotFound as nf:
             state_obj = ProcessState(state=state, ts=get_ion_ts())
-            self.state_store.create(state_obj, object_id=key)
+            id, rev = self.state_store.create(state_obj, object_id=key)
+            state_obj._id = id
+            state_obj._rev = rev
+        return state_obj
 
     def get_state(self, key):
         """
         Returns the state vector for given key (typically a process id).
         The state vector is a previously persisted object (e.g. a dict).
         In case no state was found, NotFound is raised.
-        @TODO: The actual state object around the state is lost (with _rev and ts).
+        @retval a tuple with state vector and ProcessState object
         """
         log.debug("Retrieving persistent state for key=%s", key)
         state_obj = self.state_store.read(key)
-        return state_obj.state
+        return state_obj.state, state_obj
 
 
 class StatefulProcessMixin(object):

--- a/pyon/ion/state.py
+++ b/pyon/ion/state.py
@@ -61,6 +61,12 @@ class StateRepository(object):
             self.state_store.create(state_obj, object_id=key)
 
     def get_state(self, key):
+        """
+        Returns the state vector for given key (typically a process id).
+        The state vector is a previously persisted object (e.g. a dict).
+        In case no state was found, NotFound is raised.
+        @TODO: The actual state object around the state is lost (with _rev and ts).
+        """
         log.debug("Retrieving persistent state for key=%s", key)
         state_obj = self.state_store.read(key)
         return state_obj.state

--- a/pyon/ion/state.py
+++ b/pyon/ion/state.py
@@ -40,7 +40,15 @@ class StateRepository(object):
         self.state_store.close()
 
     def put_state(self, key, state):
-        log.debug("Store persistent state for key=%s" % key)
+        """
+        Persist a private process state using the given key (typically a process id).
+        The state vector is an object (e.g. a dict) that may contain any python type that
+        is JSON-able. This means no custom objects are allowed in here.
+        WARNING: If multiple threads/greenlets persist state concurrently, e.g. based
+        on message processing and time, the calls to this method need to be protected
+        by an exclusive lock (semaphore).
+        """
+        log.debug("Store persistent state for key=%s", key)
         if not isinstance(state, dict):
             raise BadRequest("state must be type dict, not %s" % type(state))
         try:
@@ -53,7 +61,7 @@ class StateRepository(object):
             self.state_store.create(state_obj, object_id=key)
 
     def get_state(self, key):
-        log.debug("Retrieving persistent state for key=%s" % key)
+        log.debug("Retrieving persistent state for key=%s", key)
         state_obj = self.state_store.read(key)
         return state_obj.state
 

--- a/pyon/ion/test/test_state.py
+++ b/pyon/ion/test/test_state.py
@@ -44,11 +44,16 @@ class TestState(IonUnitTestCase):
         state4, state_obj4 = state_repo.get_state("id1")
         self.assertEquals(state3, state4)
 
+        # Test persisting with a prior state object to save a read
         state5 = {'key':'value5', 'key2': {}}
         state_repo.put_state("id1", state5, state_obj=state_obj4)
 
         state6, state_obj6 = state_repo.get_state("id1")
         self.assertEquals(state5, state6)
+
+        # Test that using an old state object will not screw up
+        state7 = {'key':'value7', 'key2': {}}
+        state_repo.put_state("id1", state7, state_obj=state_obj4)
 
 
 @attr('INT', group='state')

--- a/pyon/ion/test/test_state.py
+++ b/pyon/ion/test/test_state.py
@@ -31,14 +31,25 @@ class TestState(IonUnitTestCase):
         state1 = {'key':'value1'}
         state_repo.put_state("id1", state1)
 
-        state2 = state_repo.get_state("id1")
+        state2, state_obj2 = state_repo.get_state("id1")
         self.assertEquals(state1, state2)
+        self.assertEquals(state_obj2.state, state2)
+        self.assertTrue(state_obj2.ts)
+        self.assertTrue(state_obj2._rev)
+        self.assertEquals(state_obj2._id, "id1")
 
         state3 = {'key':'value2', 'key2': {}}
         state_repo.put_state("id1", state3)
 
-        state4 = state_repo.get_state("id1")
+        state4, state_obj4 = state_repo.get_state("id1")
         self.assertEquals(state3, state4)
+
+        state5 = {'key':'value5', 'key2': {}}
+        state_repo.put_state("id1", state5, state_obj=state_obj4)
+
+        state6, state_obj6 = state_repo.get_state("id1")
+        self.assertEquals(state5, state6)
+
 
 @attr('INT', group='state')
 class TestStatefulProcess(IonIntegrationTestCase):


### PR DESCRIPTION
- Fix OOIION-897: Concurrent _flush_state in greenlets now ok through lock
- Fix OOIION-806: Process state now loaded on process restart
- Process state improved update performance. Eliminate one read
- Enhancements to state repository interface: Provide the ProcessState object context
- Polish of process state handling and state repository
