### PR TITLE
Tune QoS on all amqp channels to prefetch 1 msg only

### DIFF
--- a/pyon/net/messaging.py
+++ b/pyon/net/messaging.py
@@ -183,6 +183,11 @@ class NodeB(BaseNode):
             raise StandardError("AMQCHAN IS NONE THIS SHOULD NEVER HAPPEN, chan number requested: %s" % ch_number)
 
         transport = AMQPTransport(amq_chan)
+
+        # by default, everything should have a prefetch count of 1 (configurable)
+        # this can be overridden by the channel get_n related methods
+        transport.qos_impl(prefetch_count=CFG.get_safe('container.messaging.endpoint.prefetch_count', 1))
+
         return transport
 
     def _check_pooled_channel_health(self, ch):

--- a/pyon/net/test/test_channel.py
+++ b/pyon/net/test/test_channel.py
@@ -907,6 +907,11 @@ class TestChannelInt(IonIntegrationTestCase):
         ch._recv_name = NameTrio(bootstrap.get_sys_name(), 'test_queue')
         ch._queue_auto_delete = False
 
+        # #########
+        # THIS TEST EXPECTS OLD BEHAVIOR OF NO QOS, SO SET A HIGH BAR
+        # #########
+        ch._transport.qos_impl(prefetch_count=9999)
+
         def cleanup_channel(thech):
             thech._destroy_queue()
             thech.close()

--- a/pyon/net/test/test_messaging.py
+++ b/pyon/net/test/test_messaging.py
@@ -77,7 +77,8 @@ class TestNodeB(PyonTestCase):
         self.assertNotIn(ourchid, self._node._bidir_pool)
 
     @patch('pyon.net.messaging.blocking_cb')
-    def test__new_channel(self, bcbmock):
+    @patch('pyon.net.transport.AsyncResult')
+    def test__new_channel(self, armock, bcbmock):
         self._node.client = Mock()
         ch = self._node._new_channel(BaseChannel)
 
@@ -228,7 +229,8 @@ class TestNodeB(PyonTestCase):
         self.assertEqual(chmock._destroy_queue.call_count, 20)
 
     @patch('pyon.net.messaging.blocking_cb')
-    def test__new_transport(self, bcbmock):
+    @patch('pyon.net.transport.AsyncResult')
+    def test__new_transport(self, armock, bcbmock):
         self._node.client = Mock()
         transport = self._node._new_transport()
 


### PR DESCRIPTION
UNIT/INT tests pass.

This does not technically depend on ooici/ion-definitions#366 as that just provides a reference in the configuration.  The code will use a default value of 1 which is the intention.  It can be merged in any order.
