### PR TITLE
Reomves filesystem cleanup from tests using --with-pycc

### DIFF
--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -76,16 +76,20 @@ class IonIntegrationTestCase(unittest.TestCase):
             from pyon.datastore.datastore_admin import DatastoreAdmin
             da = DatastoreAdmin(config=CFG)
             da.load_datastore('res/dd')
+            # Turn off file system cleaning
+            # The child container should NOT clean out the parent's filesystem, 
+            # they should share like good containers sometimes do
+            CFG.container.file_system.force_clean = False
         else:
             # We cannot live without pre-initialized datastores and resource objects
             pre_initialize_ion()
 
-        # hack to force_clean on filesystem
-        try:
-            CFG['container']['filesystem']['force_clean'] = True
-        except KeyError:
-            CFG['container']['filesystem'] = {}
-            CFG['container']['filesystem']['force_clean'] = True
+            # hack to force_clean on filesystem
+            try:
+                CFG['container']['filesystem']['force_clean'] = True
+            except KeyError:
+                CFG['container']['filesystem'] = {}
+                CFG['container']['filesystem']['force_clean'] = True
 
         self.container = None
         self.addCleanup(self._stop_container)


### PR DESCRIPTION
When the --with-pycc plugin is utilized a hosting container is launched
that hosts all the services and processes. This container's filesystem
is initialized and populated with information about datasets and other
system components.  When the container is done launching it signals the
nose process to go ahead and launch the container that plays host to the
tests.  This container unfortunately was deleting the filesystem!

This patches the filesystem force cleaning so that the container that
hosts the tests doesn't override and delete the parent container's file-
system.
