### PR TITLE
Change filesystem to use sysname prefix

### DIFF
--- a/pyon/util/file_sys.py
+++ b/pyon/util/file_sys.py
@@ -39,6 +39,7 @@ class FileSystem(object):
     FS_DIRECTORY = DotDict(zip(FS_DIRECTORY_LIST,FS_DIRECTORY_LIST))
 
     FS = DotDict(zip(FS_DIRECTORY_LIST, FS_DIRECTORY_LIST))
+    root = ''
     _instance = None
 
 
@@ -49,25 +50,19 @@ class FileSystem(object):
     
     @classmethod 
     def _clean(cls, config):
-        root = config.get_safe('container.filesystem.root', '/tmp')
-        for k,v in FileSystem.FS_DIRECTORY.iteritems():
-            s = v.lower() 
-            conf = config.get_safe('container.filesystem.%s' % s, None)
-            if conf:
-                FileSystem.FS_DIRECTORY[k] = conf
-            else:
-                FileSystem.FS_DIRECTORY[k] = os.path.join(os.path.join(root, get_sys_name()),s)
-            if os.path.exists(FS_DIRECTORY[k]):
-                log.info('Removing %s' , FS_DIRECTORY[k])
-                shutil.rmtree(FS_DIRECTORY[k])
+        if not cls.root:
+            cls.root = os.path.join(config.get_safe('container.filesystem.root', '/tmp'), get_sys_name())
+        log.info('Removing %s', cls.root)
+        if os.path.exists(cls.root):
+            shutil.rmtree(cls.root)
 
 
     def __init__(self, CFG):
         FileSystem._force_clean = CFG.get_safe('container.filesystem.force_clean',False)
         if FileSystem._force_clean:
             self._clean(CFG)
-
-        root = CFG.get_safe('container.filesystem.root', '/tmp')
+        if not FileSystem.root:
+            FileSystem.root = os.path.join(CFG.get_safe('container.filesystem.root', '/tmp'), get_sys_name())
 
         for k,v in FileSystem.FS_DIRECTORY.iteritems():
             s = v.lower() # Lower case string
@@ -75,7 +70,7 @@ class FileSystem(object):
             if conf:
                 FileSystem.FS_DIRECTORY[k] = conf
             else:
-                FileSystem.FS_DIRECTORY[k] = os.path.join(os.path.join(root, get_sys_name()),s)
+                FileSystem.FS_DIRECTORY[k] = os.path.join(os.path.join(FileSystem.root, get_sys_name()),s)
             # Check to make sure you're within your rights to access this
             if not FileSystem._sandbox(FileSystem.FS_DIRECTORY[k]):
                 raise OSError('You are attempting to perform an operation beyond the scope of your permission. (%s is set to \'%s\')' % (k,FileSystem.FS_DIRECTORY[k]))

--- a/pyon/util/file_sys.py
+++ b/pyon/util/file_sys.py
@@ -14,7 +14,7 @@ import random
 import string
 from pyon.util.log import log
 from pyon.util.containers import DotDict
-from pyon.core.bootstrap import CFG as bootcfg
+from pyon.core.bootstrap import CFG as bootcfg, get_sys_name
 
 
 class FileSystemError(Exception):
@@ -49,13 +49,14 @@ class FileSystem(object):
     
     @classmethod 
     def _clean(cls, config):
+        root = config.get_safe('container.filesystem.root', '/tmp')
         for k,v in FileSystem.FS_DIRECTORY.iteritems():
             s = v.lower() 
             conf = config.get_safe('container.filesystem.%s' % s, None)
             if conf:
                 FileSystem.FS_DIRECTORY[k] = conf
             else:
-                FileSystem.FS_DIRECTORY[k] = os.path.join('/tmp',s)
+                FileSystem.FS_DIRECTORY[k] = os.path.join(os.path.join(root, get_sys_name()),s)
             if os.path.exists(FS_DIRECTORY[k]):
                 log.info('Removing %s' , FS_DIRECTORY[k])
                 shutil.rmtree(FS_DIRECTORY[k])
@@ -66,13 +67,15 @@ class FileSystem(object):
         if FileSystem._force_clean:
             self._clean(CFG)
 
+        root = CFG.get_safe('container.filesystem.root', '/tmp')
+
         for k,v in FileSystem.FS_DIRECTORY.iteritems():
             s = v.lower() # Lower case string
             conf = CFG.get_safe('container.filesystem.%s' % s, None)
             if conf:
                 FileSystem.FS_DIRECTORY[k] = conf
             else:
-                FileSystem.FS_DIRECTORY[k] = os.path.join('/tmp',s)
+                FileSystem.FS_DIRECTORY[k] = os.path.join(os.path.join(root, get_sys_name()),s)
             # Check to make sure you're within your rights to access this
             if not FileSystem._sandbox(FileSystem.FS_DIRECTORY[k]):
                 raise OSError('You are attempting to perform an operation beyond the scope of your permission. (%s is set to \'%s\')' % (k,FileSystem.FS_DIRECTORY[k]))

--- a/pyon/util/file_sys.py
+++ b/pyon/util/file_sys.py
@@ -51,7 +51,7 @@ class FileSystem(object):
     @classmethod 
     def _clean(cls, config):
         if not cls.root:
-            cls.root = os.path.join(config.get_safe('container.filesystem.root', '/tmp'), get_sys_name())
+            cls.root = os.path.join(config.get_safe('container.filesystem.root', '/tmp/ion'), get_sys_name())
         log.info('Removing %s', cls.root)
         if os.path.exists(cls.root):
             shutil.rmtree(cls.root)
@@ -61,7 +61,7 @@ class FileSystem(object):
         if FileSystem._force_clean:
             self._clean(CFG)
         if not FileSystem.root:
-            FileSystem.root = os.path.join(CFG.get_safe('container.filesystem.root', '/tmp'), get_sys_name())
+            FileSystem.root = os.path.join(CFG.get_safe('container.filesystem.root', '/tmp/ion'), get_sys_name())
 
         for k,v in FileSystem.FS_DIRECTORY.iteritems():
             s = v.lower() # Lower case string

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -12,6 +12,7 @@ from pyon.core import bootstrap
 from pyon.core.bootstrap import bootstrap_pyon, CFG
 from pyon.core.interfaces.interfaces import InterfaceAdmin
 from pyon.util.log import log
+from pyon.util.file_sys import FileSystem
 
 
 def pre_initialize_ion():
@@ -142,6 +143,8 @@ class IonIntegrationTestCase(unittest.TestCase):
 
         finally:
             datastore.close()
+        FileSystem._clean(CFG)
+
 
     def patch_cfg(self, cfg_obj_or_str, *args, **kwargs):
         """

--- a/pyon/util/unit_test.py
+++ b/pyon/util/unit_test.py
@@ -6,7 +6,8 @@ from mock import Mock, mocksignature, patch, DEFAULT
 import unittest
 
 from zope.interface import implementedBy
-from pyon.core.bootstrap import IonObject, bootstrap_pyon, get_service_registry
+from pyon.core.bootstrap import IonObject, bootstrap_pyon, get_service_registry, CFG
+from pyon.util.file_sys import FileSystem
 
 bootstrap_pyon()
 
@@ -27,6 +28,10 @@ def pop_last_call(mock):
     mock.call_count -= 1
 
 class PyonTestCase(unittest.TestCase):
+    def __init__(self):
+        unittest.TestCase.__init__(self)
+
+        self.addCleanup(self._file_sys_clean)
     # Call this function at the beginning of setUp if you need a mock ion
     # obj
 
@@ -46,6 +51,12 @@ class PyonTestCase(unittest.TestCase):
         thing = patcher.start()
         self.addCleanup(patcher.stop)
         return thing
+
+    def _file_sys_clean(self):
+        if CFG.get_safe('filesystem.force_clean',None):
+            FileSystem._clean(CFG)
+
+
 
     def _create_service_mock(self, service_name):
         # set self.clients if not already set

--- a/pyon/util/unit_test.py
+++ b/pyon/util/unit_test.py
@@ -28,8 +28,8 @@ def pop_last_call(mock):
     mock.call_count -= 1
 
 class PyonTestCase(unittest.TestCase):
-    def __init__(self):
-        unittest.TestCase.__init__(self)
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
 
         self.addCleanup(self._file_sys_clean)
     # Call this function at the beginning of setUp if you need a mock ion
@@ -53,8 +53,7 @@ class PyonTestCase(unittest.TestCase):
         return thing
 
     def _file_sys_clean(self):
-        if CFG.get_safe('filesystem.force_clean',None):
-            FileSystem._clean(CFG)
+        FileSystem._clean(CFG)
 
 
 


### PR DESCRIPTION
Will isolate test runs etc and prevent filesystem clean from wrecking an active container with datasets etc
