### PR TITLE
work around memory leak by disabling multiple stacks in exceptions

### DIFF
--- a/pyon/core/exception.py
+++ b/pyon/core/exception.py
@@ -219,9 +219,10 @@ class ExceptionFactory(object):
             out = self._exception_map[str(code)](message)
         else:
             out = self._default(message)
-        if stacks:
-            for label, stack in stacks:
-                out.add_stack(label, stack)
+# TEMPORARY: disable adding stacks here until JIRA OOIION-1093 fixed to avoid memory leak
+#        if stacks:
+#            for label, stack in stacks:
+#                out.add_stack(label, stack)
         return out
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(  name = 'pyon',
         dependency_links = [
             'http://sddevrepo.oceanobservatories.org/releases/',
             'https://github.com/ooici/gevent-profiler/tarball/master#egg=python-gevent-profiler',
-            'https://github.com/ooici/utilities/tarball/v2013.05.14#egg=utilities-2013.05.14',
+            'https://github.com/ooici/utilities/tarball/v2013.06.11#egg=utilities-2013.06.11',
         ],
         test_suite = 'pyon',
         package_data = {'': ['*.xml']},


### PR DESCRIPTION
updates version of utilties to avoid automatic use of stack from exc_info
updates ExceptionFactory to drop list of stacks
