### PR TITLE
Fix OOIION-1111: Extended resource framework association direction

### DIFF
--- a/pyon/ion/resource.py
+++ b/pyon/ion/resource.py
@@ -103,17 +103,20 @@ def load_definitions():
     ot_list.append('IonObjectBase')
     ObjectTypes.clear()
     ObjectTypes.update(zip(ot_list, ot_list))
+    ObjectTypes.lock()
 
     # Resource Types
     rt_list = getextends('Resource')
     rt_list.append('Resource')
     ResourceTypes.clear()
     ResourceTypes.update(zip(rt_list, rt_list))
+    ResourceTypes.lock()
 
     # Predicate Types
     pt_list = get_predicate_type_list()
     PredicateType.clear()
     PredicateType.update(zip(pt_list, pt_list))
+    PredicateType.lock()
 
     # Compound Associations
     get_compound_associations_list()
@@ -123,16 +126,17 @@ def load_definitions():
     LifeCycleStates.clear()
     lcstates = list(CommonResourceLifeCycleSM.MATURITY)
     LifeCycleStates.update(zip(lcstates, lcstates))
+    LifeCycleStates.lock()
 
     AvailabilityStates.clear()
     avstates = list(CommonResourceLifeCycleSM.AVAILABILITY)
     AvailabilityStates.update(zip(avstates, avstates))
-
+    AvailabilityStates.lock()
 
     # Life cycle events
     LCE.clear()
     LCE.update(zip([e.upper() for e in CommonResourceLifeCycleSM.BASE_EVENTS], CommonResourceLifeCycleSM.BASE_EVENTS))
-
+    LCE.lock()
 
 def get_restype_lcsm(restype):
     return lcs_workflows.get(restype, None)

--- a/pyon/ion/resource.py
+++ b/pyon/ion/resource.py
@@ -722,6 +722,8 @@ class ExtendedResourceContainer(object):
         return False
 
     def is_association_predicate(self, association):
+        if association and (association.endswith(">") or association.endswith("<")):
+            association = association[:-1]
         return Predicates.has_key(association)
 
     def is_compound_association(self, association):
@@ -732,6 +734,11 @@ class ExtendedResourceContainer(object):
             return CompoundAssociations[association]['predicates']
 
         return list()  # If not found then return empty list
+
+    def _allow_direction(self, assoc_direction, direction):
+        if not assoc_direction:
+            return True  # Either way is fine (empty str)
+        return assoc_direction == direction
 
     def _find_associated_resources(self, resource, association_predicate, target_type=None, res_type=None):
         """
@@ -746,31 +753,46 @@ class ExtendedResourceContainer(object):
         if target_type and type(target_type) not in (list, tuple):   # None and empty str left alone
             target_type = [target_type]
 
+        assoc_direction = ""
+        if association_predicate and (association_predicate.endswith(">") or association_predicate.endswith("<")):
+            assoc_direction = association_predicate[-1]
+            association_predicate = association_predicate[:-1]
+
         # First validate the association predicate
         pred = Predicates[association_predicate]
         if not pred:
-            return assoc_list  # Unknown association type so return empty list
+            return []  # Unknown association type so return empty list
 
         # Need to check through all of these in this order to account for specific vs base class inclusions
-        if self.is_predicate_association(pred, 'domain', res_type):
+        # @ TODO: This algorithm and the order is fragile
+        if self.is_predicate_association(pred, 'domain', res_type) and self._allow_direction(assoc_direction, ">"):
+            # Case 1: Association in schema with current exact resource type as SUBJECT
+
+            assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=False))
+
+            # If no objects were found, try finding as subjects just in case (unless direction requested)
+            if not assoc_list and not assoc_direction:
+                assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=True))
+
+        elif self.is_predicate_association(pred, 'range', res_type) and self._allow_direction(assoc_direction, "<"):
+            # Case 2: Association in schema with current exact resource type as OBJECT
+
+            assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=True))
+
+        elif self.is_predicate_association_extension(pred, 'domain', res_type) and self._allow_direction(assoc_direction, ">"):
+            # Case 3: Association in schema with base type of current resource type as SUBJECT
             assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=False))
 
             # If no objects were found, try finding as subjects just in case.
-            if not assoc_list:
+            if not assoc_list and not assoc_direction:
                 assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=True))
 
-        elif self.is_predicate_association(pred, 'range', res_type):
+        elif self.is_predicate_association_extension(pred, 'range', res_type) and self._allow_direction(assoc_direction, "<"):
+            # Case 4: Association in schema with base type of current resource type as OBJECT
             assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=True))
 
-        elif self.is_predicate_association_extension(pred, 'domain', res_type):
-            assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=False))
-
-            # If no objects were found, try finding as subjects just in case.
-            if not assoc_list:
-                assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=True))
-
-        elif self.is_predicate_association_extension(pred, 'range', res_type):
-            assoc_list.extend(self._find_associations(resource_id, association_predicate, target_type, backward=True))
+        else:
+            log.warn("Cannot handle association predicate %s for resource type %s", association_predicate, res_type)
 
         return assoc_list
 

--- a/pyon/ion/test/test_resource.py
+++ b/pyon/ion/test/test_resource.py
@@ -139,7 +139,7 @@ class TestResources(IonUnitTestCase):
         Instrument_device_to_actor_identity_association = Mock()
         Instrument_device_to_actor_identity_association._id = '666'
         Instrument_device_to_actor_identity_association.s = "123"
-        Instrument_device_to_actor_identity_association.st = RT.InstumentDevice
+        Instrument_device_to_actor_identity_association.st = RT.InstrumentDevice
         Instrument_device_to_actor_identity_association.p = PRED.hasOwner
         Instrument_device_to_actor_identity_association.o = "111"
         Instrument_device_to_actor_identity_association.ot = RT.ActorIdentity
@@ -149,7 +149,7 @@ class TestResources(IonUnitTestCase):
         Instrument_device_to_actor_identity_association2 = Mock()
         Instrument_device_to_actor_identity_association2._id = '667'
         Instrument_device_to_actor_identity_association2.s = "456"
-        Instrument_device_to_actor_identity_association2.st = RT.InstumentDevice
+        Instrument_device_to_actor_identity_association2.st = RT.InstrumentDevice
         Instrument_device_to_actor_identity_association2.p = PRED.hasOwner
         Instrument_device_to_actor_identity_association2.o = "111"
         Instrument_device_to_actor_identity_association2.ot = RT.ActorIdentity

--- a/pyon/util/containers.py
+++ b/pyon/util/containers.py
@@ -67,7 +67,7 @@ class DotDict(DotNotationGetItem, dict):
 
 
     def __dir__(self):
-        return [k for k in self.__dict__.keys() + self.keys() if DICT_LOCKING_ATTR != k]
+        return [k for k in self.__dict__.keys() + self.keys() if k != DICT_LOCKING_ATTR]
 
     def __getattr__(self, key):
         """ Make attempts to lookup by nonexistent attributes also attempt key lookups. """
@@ -113,11 +113,6 @@ class DotDict(DotNotationGetItem, dict):
     def clear(self):
         dict.__setattr__(self, DICT_LOCKING_ATTR, False)
         super(DotDict, self).clear()
-
-    def pop(self, *args, **kwargs):
-        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
-            raise AttributeError('Cannot pop on a locked DotDict')
-        super(DotDict, self).pop(*args, **kwargs)
 
     def pop(self, *args, **kwargs):
         if dict.__getattribute__(self, DICT_LOCKING_ATTR):

--- a/pyon/util/containers.py
+++ b/pyon/util/containers.py
@@ -14,6 +14,8 @@ import os
 import re
 from copy import deepcopy
 
+DICT_LOCKING_ATTR = "__locked__"
+
 class DotNotationGetItem(object):
     """ Drive the behavior for DotList and DotDict lookups by dot notation, JSON-style. """
 
@@ -59,25 +61,34 @@ class DotDict(DotNotationGetItem, dict):
     do not use in performance-critical parts of your code.
     """
 
+    def __init__(self, *args, **kwargs):
+        dict.__setattr__(self, DICT_LOCKING_ATTR, False)
+        super(DotDict, self).__init__(*args, **kwargs)
+
+
     def __dir__(self):
-        return self.__dict__.keys() + self.keys()
+        return [k for k in self.__dict__.keys() + self.keys() if DICT_LOCKING_ATTR != k]
 
     def __getattr__(self, key):
         """ Make attempts to lookup by nonexistent attributes also attempt key lookups. """
         if self.has_key(key):
             return self[key]
-        import sys
-        import dis
-        frame = sys._getframe(1)
-        if '\x00%c' % dis.opmap['STORE_ATTR'] in frame.f_code.co_code:
-            self[key] = DotDict()
-            return self[key]
+
+        if not dict.__getattribute__(self, DICT_LOCKING_ATTR):
+            import sys
+            import dis
+            frame = sys._getframe(1)
+            if '\x00%c' % dis.opmap['STORE_ATTR'] in frame.f_code.co_code:
+                self[key] = DotDict()
+                return self[key]
 
         raise AttributeError(key)
 
-    def __setattr__(self,key,value):
+    def __setattr__(self, key, value):
         if key in dir(dict):
             raise AttributeError('%s conflicts with builtin.' % key)
+        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+            raise AttributeError('Setting %s on a locked DotDict' % key)
         if isinstance(value, dict):
             self[key] = DotDict(value)
         else:
@@ -95,6 +106,29 @@ class DotDict(DotNotationGetItem, dict):
         if value is None:
             value = default
         return value
+
+    def lock(self):
+        dict.__setattr__(self, DICT_LOCKING_ATTR, True)
+
+    def clear(self):
+        dict.__setattr__(self, DICT_LOCKING_ATTR, False)
+        super(DotDict, self).clear()
+
+    def pop(self, *args, **kwargs):
+        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+            raise AttributeError('Cannot pop on a locked DotDict')
+        super(DotDict, self).pop(*args, **kwargs)
+
+    def pop(self, *args, **kwargs):
+        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+            raise AttributeError('Cannot pop on a locked DotDict')
+        super(DotDict, self).pop(*args, **kwargs)
+
+    def popitem(self):
+        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+            raise AttributeError('Cannot popitem on a locked DotDict')
+        super(DotDict, self).popitem()
+
 
     @classmethod
     def fromkeys(cls, seq, value=None):

--- a/pyon/util/containers.py
+++ b/pyon/util/containers.py
@@ -62,7 +62,6 @@ class DotDict(DotNotationGetItem, dict):
     """
 
     def __init__(self, *args, **kwargs):
-        dict.__setattr__(self, DICT_LOCKING_ATTR, False)
         super(DotDict, self).__init__(*args, **kwargs)
 
 
@@ -74,7 +73,7 @@ class DotDict(DotNotationGetItem, dict):
         if self.has_key(key):
             return self[key]
 
-        if not dict.__getattribute__(self, DICT_LOCKING_ATTR):
+        if not hasattr(self, DICT_LOCKING_ATTR):
             import sys
             import dis
             frame = sys._getframe(1)
@@ -87,7 +86,7 @@ class DotDict(DotNotationGetItem, dict):
     def __setattr__(self, key, value):
         if key in dir(dict):
             raise AttributeError('%s conflicts with builtin.' % key)
-        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+        if hasattr(self, DICT_LOCKING_ATTR):
             raise AttributeError('Setting %s on a locked DotDict' % key)
         if isinstance(value, dict):
             self[key] = DotDict(value)
@@ -111,16 +110,18 @@ class DotDict(DotNotationGetItem, dict):
         dict.__setattr__(self, DICT_LOCKING_ATTR, True)
 
     def clear(self):
-        dict.__setattr__(self, DICT_LOCKING_ATTR, False)
+        if hasattr(self, DICT_LOCKING_ATTR):
+            dict.__delattr__(self, DICT_LOCKING_ATTR)
+
         super(DotDict, self).clear()
 
     def pop(self, *args, **kwargs):
-        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+        if hasattr(self, DICT_LOCKING_ATTR):
             raise AttributeError('Cannot pop on a locked DotDict')
         super(DotDict, self).pop(*args, **kwargs)
 
     def popitem(self):
-        if dict.__getattribute__(self, DICT_LOCKING_ATTR):
+        if hasattr(self, DICT_LOCKING_ATTR):
             raise AttributeError('Cannot popitem on a locked DotDict')
         super(DotDict, self).popitem()
 

--- a/pyon/util/test/test_containers.py
+++ b/pyon/util/test/test_containers.py
@@ -28,13 +28,31 @@ class Test_Containers(IonIntegrationTestCase):
         d.foo = "somethingnew"
         self.assertEqual("somethingnew", d.foo)
 
+        # DotDict only checks that an assignment operation is happening when it creates dummy entries
+        # ... it doesn't check that the dummy entry is on the left hand side of the assignment
+        k = d.foo1
+        self.assertIn("foo1", dir(d))
+
         d.lock()
+
+        # test assigning directly to a locked dict
         with self.assertRaises(AttributeError):
             d.foo = "somethingelse"
-
         self.assertEqual("somethingnew", d.foo)
 
+        # test dummy-creation-on-assignment loophole
+        with self.assertRaises(AttributeError):
+            k = d.foo2
+        self.assertNotIn("foo2", dir(d))
+
+        # test alternate dummy creation method: calling a function with it
+        with self.assertRaises(AttributeError):
+            k = lambda _: True
+            k(d.foo3)
+        self.assertNotIn("foo3", dir(d))
+
         self.assertNotIn(DICT_LOCKING_ATTR, dir(d))
+
 
     def test_dotdict_chaining(self):
         base = DotDict({'test':None})

--- a/pyon/util/test/test_containers.py
+++ b/pyon/util/test/test_containers.py
@@ -7,6 +7,7 @@ import copy
 from nose.plugins.attrib import attr
 
 from pyon.util.containers import DotDict, create_unique_identifier, make_json, is_valid_identifier, is_basic_identifier, NORMAL_VALID, is_valid_ts, get_ion_ts, dict_merge, DictDiffer
+from pyon.util.containers import DICT_LOCKING_ATTR
 from pyon.util.int_test import IonIntegrationTestCase
 
 
@@ -20,6 +21,20 @@ class Test_Containers(IonIntegrationTestCase):
         dotDict.a = "1"
         self.assertEqual(dotDict.a, "1")
         self.assertTrue('a' in dotDict)
+
+    def test_dot_dict_constant(self):
+        d = DotDict({"foo": "bar"})
+        self.assertEqual("bar", d.foo)
+        d.foo = "somethingnew"
+        self.assertEqual("somethingnew", d.foo)
+
+        d.lock()
+        with self.assertRaises(AttributeError):
+            d.foo = "somethingelse"
+
+        self.assertEqual("somethingnew", d.foo)
+
+        self.assertNotIn(DICT_LOCKING_ATTR, dir(d))
 
     def test_dotdict_chaining(self):
         base = DotDict({'test':None})


### PR DESCRIPTION
This fix allows to specify the association direction in extended resource framework decorators. This is important when a resource type uses the same predicate for incoming and outgoing associations, e.g. sites that are recursively nested.

Example:
  #@hasSite<
  parent_site: !Site      # The immediate parent of this site (if any)

  #@hasSite>
  child_sites: []

  #@hasSite>=InstrumentSite
  child_instrument_sites: []

Extensive tests were added.
