### PR TITLE
Fix/prevent OOIION-1114. Intermittent errors in container when CEI starts processes

### DIFF
--- a/pyon/__init__.py
+++ b/pyon/__init__.py
@@ -40,11 +40,10 @@ if 'pydevd' in sys.modules:
 else:
     from gevent import monkey; monkey.patch_all()
 
-
+# Fix AttributeError("'_DummyThread' object has no attribute '_Thread__block'",) issue (OOIION-621)
+# http://stackoverflow.com/questions/13193278/understand-python-threading-bug
+import threading
 try:
-    # Fix AttributeError("'_DummyThread' object has no attribute '_Thread__block'",) issue (OOIION-621)
-    # http://stackoverflow.com/questions/13193278/understand-python-threading-bug
-    import threading
     threading._DummyThread._Thread__stop = lambda x: 42
 except Exception as ex:
     pass

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -775,9 +775,11 @@ class ProcManager(object):
         if process_instance._proc_type == SERVICE_PROCESS_TYPE:
             if self.container.has_capability(self.container.CCAP.RESOURCE_REGISTRY):
                 # Registration of SERVICE process: in resource registry
-                service_list, _ = self.container.resource_registry.find_resources(restype="Service", name=process_instance.name)
+                service_list, _ = self.container.resource_registry.find_resources(restype="Service", name=process_instance.name, id_only=True)
                 if service_list:
-                    process_instance._proc_svc_id = service_list[0]._id
+                    process_instance._proc_svc_id = service_list[0]
+                    if len(service_list) > 1:
+                        log.warn("More than 1 Service resource found with name %s: %s", process_instance.name, service_list)
                 else:
                     # We are starting the first process of a service instance
                     # TODO: This should be created by the HA Service agent in the future
@@ -786,10 +788,12 @@ class ProcManager(object):
 
                     # Create association to service definition resource
                     svcdef_list, _ = self.container.resource_registry.find_resources(restype="ServiceDefinition",
-                        name=process_instance.name)
+                        name=process_instance.name, id_only=True)
                     if svcdef_list:
+                        if len(svcdef_list) > 1:
+                            log.warn("More than 1 ServiceDefinition resource found with name %s: %s", process_instance.name, svcdef_list)
                         self.container.resource_registry.create_association(process_instance._proc_svc_id,
-                            "hasServiceDefinition", svcdef_list[0]._id)
+                            "hasServiceDefinition", svcdef_list[0])
                     else:
                         log.error("Cannot find ServiceDefinition resource for %s", process_instance.name)
 

--- a/pyon/datastore/couchdb/couchdb_datastore.py
+++ b/pyon/datastore/couchdb/couchdb_datastore.py
@@ -927,6 +927,9 @@ class CouchDB_DataStore(DataStore):
             return (res_ids, res_assocs)
         else:
             res_docs = [self._persistence_dict_to_ion_object(row.doc) for row in rows]
+            if [True for doc in res_docs if doc is None]:
+                res_ids = [row.id for row in rows]
+                log.error("Datastore returned None docs despite include_docs==True.\nids=%s\ndocs=%s\nassocs=%s", res_ids, res_docs, res_assocs)
             return (res_docs, res_assocs)
 
     def find_res_by_type(self, restype, lcstate=None, id_only=False, filter=None):


### PR DESCRIPTION
This fix does the following
- Find Service resource by id instead of unnecessary object (prevents the issue from occurring)
- Add a warning if the datastore returns None docs despite include_docs=True
