### PR TITLE
Fix problem typos in DotDict's pop() and popitem() 

### DIFF
--- a/pyon/core/security/authentication.py
+++ b/pyon/core/security/authentication.py
@@ -43,9 +43,9 @@ class Authentication(object):
         self.white_list = []
 
         # Look for certificates and keys in "the usual places"
-        certstore_path = self.certstore = CFG.authentication.get('certstore', CERTSTORE_PATH)
+        certstore_path = self.certstore = CFG.get_safe('authentication.certstore', CERTSTORE_PATH)
         log.debug("certstore_path: %s" % str(certstore_path))
-        keystore_path = self.certstore = CFG.authentication.get('keystore', KEYSTORE_PATH)
+        keystore_path = self.certstore = CFG.get_safe('authentication.keystore', KEYSTORE_PATH)
         log.debug("keystore_path: %s" % str(keystore_path))
 
         if certstore_path and keystore_path:

--- a/pyon/util/containers.py
+++ b/pyon/util/containers.py
@@ -69,7 +69,7 @@ class DotDict(DotNotationGetItem, dict):
         if self.has_key(key):
             return self[key]
 
-        if not self.has_key(DICT_LOCKING_ATTR):
+        if not hasattr(self, DICT_LOCKING_ATTR):
             import sys
             import dis
             frame = sys._getframe(1)
@@ -82,7 +82,7 @@ class DotDict(DotNotationGetItem, dict):
     def __setattr__(self, key, value):
         if key in dir(dict):
             raise AttributeError('%s conflicts with builtin.' % key)
-        if self.has_key(DICT_LOCKING_ATTR):
+        if hasattr(self, DICT_LOCKING_ATTR):
             raise AttributeError('Setting %s on a locked DotDict' % key)
         if isinstance(value, dict):
             self[key] = DotDict(value)
@@ -103,24 +103,23 @@ class DotDict(DotNotationGetItem, dict):
         return value
 
     def lock(self):
-        pass
-    #     dict.__setattr__(self, DICT_LOCKING_ATTR, True)
-    #
-    # def clear(self):
-    #     if self.has_key(DICT_LOCKING_ATTR):
-    #         dict.__delattr__(self, DICT_LOCKING_ATTR)
-    #
-    #     super(DotDict, self).clear()
-    #
-    # def pop(self, *args, **kwargs):
-    #     if self.has_key(DICT_LOCKING_ATTR):
-    #         raise AttributeError('Cannot pop on a locked DotDict')
-    #     super(DotDict, self).pop(*args, **kwargs)
-    #
-    # def popitem(self):
-    #     if self.has_key(DICT_LOCKING_ATTR):
-    #         raise AttributeError('Cannot popitem on a locked DotDict')
-    #     super(DotDict, self).popitem()
+        dict.__setattr__(self, DICT_LOCKING_ATTR, True)
+
+    def clear(self):
+        if hasattr(self, DICT_LOCKING_ATTR):
+            dict.__delattr__(self, DICT_LOCKING_ATTR)
+
+        super(DotDict, self).clear()
+
+    def pop(self, *args, **kwargs):
+        if hasattr(self, DICT_LOCKING_ATTR):
+            raise AttributeError('Cannot pop on a locked DotDict')
+        return super(DotDict, self).pop(*args, **kwargs)
+
+    def popitem(self):
+        if hasattr(self, DICT_LOCKING_ATTR):
+            raise AttributeError('Cannot popitem on a locked DotDict')
+        return super(DotDict, self).popitem()
 
 
     @classmethod

--- a/pyon/util/test/test_containers.py
+++ b/pyon/util/test/test_containers.py
@@ -10,7 +10,6 @@ from pyon.util.containers import DotDict, create_unique_identifier, make_json, i
 from pyon.util.containers import DICT_LOCKING_ATTR
 from pyon.util.int_test import IonIntegrationTestCase
 
-
 @attr('UNIT', group='util')
 class Test_Containers(IonIntegrationTestCase):
 
@@ -52,6 +51,39 @@ class Test_Containers(IonIntegrationTestCase):
         self.assertNotIn("foo3", dir(d))
 
         self.assertNotIn(DICT_LOCKING_ATTR, dir(d))
+
+    def test_dotdict_copy(self):
+        d = DotDict({"foo": "bar"})
+        d2 = copy.copy(d)
+        self.assertTrue(hasattr(d2, "foo"))
+        self.assertEqual("bar", d2.foo)
+
+        # output_streams = copy(self.CFG.get_safe('process.publish_streams'))
+        v = "a12345"
+        CFG = DotDict()
+        CFG.process.publish_streams.salinity = v
+        print "CFG =", CFG
+        self.assertTrue(hasattr(CFG.process.publish_streams, "salinity"))
+        self.assertEqual(v, CFG.process.publish_streams.salinity)
+        self.assertEqual(v, CFG.get_safe("process.publish_streams").salinity)
+        self.assertEqual(v, copy.copy(CFG.get_safe("process.publish_streams")).salinity)
+
+        output_streams = copy.copy(CFG.get_safe("process.publish_streams"))
+        print "output_streams =", output_streams
+        self.assertTrue(hasattr(output_streams, "salinity"))
+        print "output_streams.salinity =", output_streams.salinity
+        self.assertEqual(v, output_streams.salinity)
+
+        first_stream = output_streams.popitem()
+        print "first_stream =", first_stream
+        self.assertEqual(v, first_stream[1])
+
+        d.lock()
+        dl = copy.copy(d)
+        self.assertTrue(hasattr(dl, "foo"))
+        self.assertEqual("bar", dl.foo)
+        with self.assertRaises(AttributeError):
+            d.foo2 = "nope"
 
 
     def test_dotdict_chaining(self):


### PR DESCRIPTION
This fixes a glaring error in DotDict where the return values of pop() and popitem() were not being returned.  

In the course of diagnosing this error, found a stray use of CFG.get instead of CFG.get_safe for a multi-level dict lookup.
