### PR TITLE
Generate container stats on event trigger

### DIFF
--- a/pyon/container/management.py
+++ b/pyon/container/management.py
@@ -27,12 +27,15 @@ import gc
 from threading import Lock
 
 from ooi.logging import log, config
-from pyon.ion.event import EventPublisher, EventSubscriber
-from pyon.core import bootstrap
-from pyon.core.bootstrap import IonObject
 from ooi.timer import get_accumulators
 
-from interface.objects import ContainerManagementRequest, ChangeLogLevel, ReportStatistics, ClearStatistics, ResetPolicyCache, TriggerGarbageCollection
+from pyon.ion.event import EventPublisher, EventSubscriber
+from pyon.container.snapshot import ContainerSnapshot
+from pyon.core import bootstrap
+from pyon.core.bootstrap import IonObject
+
+from interface.objects import ContainerManagementRequest, ChangeLogLevel, ReportStatistics, ClearStatistics, \
+    ResetPolicyCache, TriggerGarbageCollection, TriggerContainerSnapshot, PrepareSystemShutdown
 
 
 # define selectors to determine if this message should be handled by this container.
@@ -43,14 +46,19 @@ class ContainerSelector(object):
     """
     def __init__(self, peer):
         self.peer = peer
+
     def should_handle(self, container):
         raise Exception('subclass must override this method')
+
     def get_peer(self):
         return IonObject(self.get_peer_class(), **self.get_peer_args())
+
     def get_peer_class(self):
         return self.__class__.__name__
+
     def get_peer_args(self):
         return {}
+
     def __str__(self):
         return self.__class__.__name__
 
@@ -62,6 +70,7 @@ class ContainerSelector(object):
         subclass = getattr(sys.modules[mod], clazz)
         return subclass(obj)
 
+
 class AllContainers(ContainerSelector):
     """ all containers should perform the action """
     def should_handle(self, container):
@@ -72,7 +81,6 @@ class AllContainers(ContainerSelector):
 #class ContainersByIP(ContainerSelector):
 #class ContainersRunningProcess(ContainerSelector):
 #class ContainersInExecutionEngine(ContainerSelector):
-
 
 
 # define types of messages that can be sent and handled
@@ -87,11 +95,13 @@ class EventHandler(object):
         """ subclass should implement better name if behavior varies with args """
         return self.__class__.__name__
 
+
 class LogLevelHandler(EventHandler):
     def can_handle_request(self, action):
         return isinstance(action, ChangeLogLevel)
     def handle_request(self, action):
         config.set_level(action.logger, action.level, action.recursive)
+
 
 class StatisticsHandler(EventHandler):
     def can_handle_request(self, action):
@@ -104,6 +114,7 @@ class StatisticsHandler(EventHandler):
             for a in get_accumulators().values():
                 a.clear()
 
+
 class PolicyCacheHandler(EventHandler):
     def can_handle_request(self, action):
         return isinstance(action, ResetPolicyCache)
@@ -111,11 +122,42 @@ class PolicyCacheHandler(EventHandler):
         if bootstrap.container_instance.has_capability(bootstrap.container_instance.CCAP.GOVERNANCE_CONTROLLER):
             bootstrap.container_instance.governance_controller.reset_policy_cache()
 
+
 class GarbageCollectionHandler(EventHandler):
     def can_handle_request(self, action):
         return isinstance(action, TriggerGarbageCollection)
     def handle_request(self, action):
         gc.collect()
+
+
+class ContainerSnapshotHandler(EventHandler):
+    def can_handle_request(self, action):
+        return isinstance(action, TriggerContainerSnapshot)
+    def handle_request(self, action):
+        try:
+            cs = ContainerSnapshot(bootstrap.container_instance)
+            if action.clear_all:
+                cs.clear_snapshots()
+                log.info("Container %s snapshot cleared (id=%s)" % (bootstrap.container_instance.id,
+                                                                    bootstrap.container_instance.proc_manager.cc_id))
+                return
+
+            cs.take_snapshot(action.include_snapshots, action.exclude_snapshots)
+            if action.persist_snapshot:
+                cs.persist_snapshot()
+                log.info("Container %s snapshot persisted (id=%s)" % (bootstrap.container_instance.id,
+                                                                      bootstrap.container_instance.proc_manager.cc_id))
+            else:
+                cs.log_snapshot()
+        except Exception as ex:
+            log.warn("Error taking container snapshot", exc_info=True)
+
+
+class PrepareSystemShutdownHandler(EventHandler):
+    def can_handle_request(self, action):
+        return isinstance(action, PrepareSystemShutdown)
+    def handle_request(self, action):
+        pass
 
 
 # TODO: other useful administrative actions
@@ -126,9 +168,11 @@ class GarbageCollectionHandler(EventHandler):
 
 # event listener to handle the messages
 
-SEND_RESULT_IF_NOT_SELECTED=False # terrible idea... but might want for debug or audit?
+SEND_RESULT_IF_NOT_SELECTED = False  # terrible idea... but might want for debug or audit?
 
-DEFAULT_HANDLERS = [ LogLevelHandler(), StatisticsHandler(), PolicyCacheHandler(), GarbageCollectionHandler() ]
+DEFAULT_HANDLERS = [ LogLevelHandler(), StatisticsHandler(), PolicyCacheHandler(), GarbageCollectionHandler(),
+                     ContainerSnapshotHandler(), PrepareSystemShutdownHandler() ]
+
 
 class ContainerManager(object):
     def __init__(self, container, handlers=DEFAULT_HANDLERS):

--- a/pyon/container/management.py
+++ b/pyon/container/management.py
@@ -142,7 +142,8 @@ class ContainerSnapshotHandler(EventHandler):
                                                                     bootstrap.container_instance.proc_manager.cc_id))
                 return
 
-            cs.take_snapshot(action.include_snapshots, action.exclude_snapshots)
+            cs.take_snapshot(snapshot_id=action.snapshot_id, snapshot_kwargs=action.snapshot_kwargs,
+                             include_list=action.include_snapshots, exclude_list=action.exclude_snapshots)
             if action.persist_snapshot:
                 cs.persist_snapshot()
                 log.info("Container %s snapshot persisted (id=%s)" % (bootstrap.container_instance.id,
@@ -157,6 +158,10 @@ class PrepareSystemShutdownHandler(EventHandler):
     def can_handle_request(self, action):
         return isinstance(action, PrepareSystemShutdown)
     def handle_request(self, action):
+        # TODO: Perform some sensible action here
+        # Mode: stop all listeners from consuming
+        # Mode: disconnect all listerers
+        # Mode: interrupt all processing
         pass
 
 

--- a/pyon/container/procs.py
+++ b/pyon/container/procs.py
@@ -403,6 +403,7 @@ class ProcManager(object):
                                    listeners=[rsvc1, rsvc2],
                                    proc_name=process_instance._proc_name,
                                    cleanup_method=cleanup)
+        proc.proc._glname = "ION Proc %s" % process_instance._proc_name
         self.proc_sup.ensure_ready(proc, "_spawn_service_process for %s" % ",".join((listen_name, process_instance.id)))
 
         # map gproc to process_instance
@@ -458,6 +459,7 @@ class ProcManager(object):
                                    listeners=[rsvc, process_instance.stream_subscriber],
                                    proc_name=process_instance._proc_name,
                                    cleanup_method=cleanup)
+        proc.proc._glname = "ION Proc %s" % process_instance._proc_name
         self.proc_sup.ensure_ready(proc, "_spawn_stream_process for %s" % process_instance._proc_name)
 
         # map gproc to process_instance
@@ -518,6 +520,7 @@ class ProcManager(object):
                                    listeners=listeners,
                                    proc_name=process_instance._proc_name,
                                    cleanup_method=agent_cleanup)
+        proc.proc._glname = "ION Proc %s" % process_instance._proc_name
         self.proc_sup.ensure_ready(proc, "_spawn_agent_process for %s" % process_instance.id)
 
         # map gproc to process_instance
@@ -574,6 +577,7 @@ class ProcManager(object):
                                    listeners=[rsvc],
                                    proc_name=process_instance._proc_name,
                                    cleanup_method=cleanup)
+        proc.proc._glname = "ION Proc %s" % process_instance._proc_name
         self.proc_sup.ensure_ready(proc, "_spawn_standalone_process for %s" % process_instance.id)
 
         # map gproc to process_instance
@@ -617,6 +621,7 @@ class ProcManager(object):
                                    listeners=[],
                                    proc_name=process_instance._proc_name,
                                    cleanup_method=cleanup)
+        proc.proc._glname = "ION Proc %s" % process_instance._proc_name
         self.proc_sup.ensure_ready(proc, "_spawn_simple_process for %s" % process_instance.id)
 
         # map gproc to process_instance

--- a/pyon/container/snapshot.py
+++ b/pyon/container/snapshot.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+__author__ = 'Michael Meisinger'
+
+import os
+import pprint
+import socket
+import sys
+
+from ooi.timer import get_accumulators
+
+from pyon.public import log, IonObject, BadRequest, CFG
+from pyon.util.containers import get_ion_ts
+
+DEFAULT_SNAPSHOTS = ["basic", "config", "processes", "policy", "accumulators", "gevent"]
+
+
+class ContainerSnapshot(object):
+    def __init__(self, container):
+        self.container = container
+        self.snapshot = {}
+        self.snap_ts = None
+        self.snapshots = list(DEFAULT_SNAPSHOTS)
+
+    def take_snapshot(self, include_list=None, exclude_list=None):
+        if include_list:
+            self.snapshots.extend(include_list)
+        if exclude_list:
+            for item in exclude_list:
+                self.snapshots.remove(item)
+
+        self.snapshot["snapshot_list"] = self.snapshots
+        for snap in self.snapshots:
+            snap_func = "_snap_%s" % snap
+            func = getattr(self, snap_func, None)
+            if func:
+                try:
+                    snap_result = func()
+                except Exception as ex:
+                    log.warn("Could not take snapshot %s: %s" % (snap, str(ex)))
+                    snap_result = ["ERROR", str(ex)]
+                self.snapshot[snap] = snap_result
+            else:
+                log.warn("Snapshot function %s undefined" % snap_func)
+
+        self.snap_ts = get_ion_ts()
+        self.snapshot["snapshot_ts"] = self.snap_ts
+
+    def persist_snapshot(self):
+        cc_id = self.container.proc_manager.cc_id
+        cc_obj = self.container.resource_registry.read(cc_id)
+        cc_obj.status_log.insert(0, self.snapshot)
+        cc_obj.status_log = cc_obj.status_log[:3]
+        self.container.resource_registry.update(cc_obj)
+
+    def log_snapshot(self):
+        log.info("Container snapshot taken at %s" % self.snap_ts)
+        log.info(pprint.pformat(self.snapshot))
+
+    def clear_snapshots(self):
+        cc_id = self.container.proc_manager.cc_id
+        cc_obj = self.container.resource_registry.read(cc_id)
+        cc_obj.status_log = []
+        self.container.resource_registry.update(cc_obj)
+
+    # -------------------------------------------------------------------------
+
+    def _snap_basic(self):
+        snap_result = {}
+        snap_result["os.uname"] = os.uname()
+        snap_result["os.getpid"] = os.getpid()
+        snap_result["os.getppid"] = os.getppid()
+        snap_result["socket.gethostname"] = socket.gethostname()
+        snap_result["socket.gethostbyname"] = socket.gethostbyname(socket.gethostname())
+        snap_result["sys.argv"] = sys.argv
+        snap_result["sys.version"] = sys.version
+        snap_result["sys.subversion"] = sys.subversion
+
+        return snap_result
+
+    def _snap_config(self):
+        snap_result = {}
+        snap_result["os.environ"] = dict(os.environ)
+        snap_result["CFG"] = CFG
+        snap_result["sys.modules"] = {n:str(m) for (n,m) in sys.modules.iteritems()}
+        snap_result["sys.path"] = sys.path
+
+        return snap_result
+
+    def _snap_gevent(self):
+        snap_result = {}
+
+        greenlet_list = []
+        snap_result["greenlets"] = greenlet_list
+        import gc
+        import traceback
+        from greenlet import greenlet
+
+        greenlets = []
+        for ob in gc.get_objects():
+            if not isinstance(ob, greenlet):
+                continue
+            if not ob:
+                continue
+            greenlets.append(ob)
+        for ob in greenlets:
+            greenlet_list.append((getattr(ob, "kwargs", ""), ''.join(traceback.format_stack(ob.gr_frame))))
+        return snap_result
+
+    def _snap_processes(self):
+        proc_mgr = self.container.proc_manager
+        snap_result = {}
+        procs_dict = {}
+        snap_result["procs"] = procs_dict
+        for proc_id, proc in proc_mgr.procs.iteritems():
+            procs_dict[proc_id] = dict(interface_name=proc.name,
+                                       proc_name=proc._proc_name,
+                                       proc_type=getattr(proc, "_proc_type", ""),
+                                       proc_listen_name=getattr(proc, "_proc_listen_name", ""),
+                                       proc_res_id=getattr(proc, "_proc_res_id", ""),
+                                       proc_start_time=getattr(proc, "_proc_start_time", ""),
+                                       proc_svc_id=getattr(proc, "_proc_svc_id", ""),
+                                       resource_id=getattr(proc, "resource_id", ""),
+                                       time_stats=proc._process.time_stats
+                                  )
+
+        return snap_result
+
+    def _snap_policy(self):
+        gov_ctrl = self.container.governance_controller
+        policies = gov_ctrl.get_active_policies()
+        snap_result = {}
+
+        common_list = []
+        snap_result["common_pdp"] = common_list
+        for rule in policies.get("common_service_access", {}).policy.rules:
+            rule_dict = dict(id=rule.id, description=rule.description, effect=rule.effect.value)
+            common_list.append(rule_dict)
+
+        service_dict = {}
+        snap_result["service_pdp"] = service_dict
+        for (svc_name, sp) in policies.get("service_access", {}).iteritems():
+            for rule in sp.policy.rules:
+                if svc_name not in service_dict:
+                    service_dict[svc_name] = []
+                rule_dict = dict(id=rule.id, description=rule.description, effect=rule.effect.value)
+                service_dict[svc_name].append(rule_dict)
+
+        service_pre_dict = {}
+        snap_result["service_precondition"] = service_pre_dict
+        for (svc_name, sp) in policies.get("service_operation", {}).iteritems():
+            for op, f in sp.iteritems():
+                if svc_name not in service_pre_dict:
+                    service_pre_dict[svc_name] = []
+                service_pre_dict[svc_name].append(op)
+
+        resource_dict = {}
+        snap_result["resource_pdp"] = resource_dict
+        for (res_name, sp) in policies.get("resource_access", {}).iteritems():
+            for rule in sp.policy.rules:
+                if res_name not in service_dict:
+                    resource_dict[res_name] = []
+                rule_dict = dict(id=rule.id, description=rule.description, effect=rule.effect.value)
+                resource_dict[res_name].append(rule_dict)
+
+        return snap_result
+
+    def _snap_accumulators(self):
+        all_acc_dict = {}
+        for acc_name, acc in get_accumulators().iteritems():
+            acc_dict = {}
+            acc_name = acc_name.split(".")[-1]
+            acc_name = acc_name[:30]
+            all_acc_dict[acc_name] = acc_dict
+            for key in acc.keys():
+                count = acc.get_count(key)
+                if count:
+                    acc_dict[key] = dict(
+                        _key=key,
+                        count=count,
+                        sum=str(acc.get_average(key) * count),
+                        min=str(acc.get_min(key)),
+                        avg=str(acc.get_average(key)),
+                        max=str(acc.get_max(key)),
+                        sdev=str(acc.get_standard_deviation(key))
+                    )
+
+        return all_acc_dict

--- a/pyon/container/snapshot.py
+++ b/pyon/container/snapshot.py
@@ -82,7 +82,7 @@ class ContainerSnapshot(object):
         snap_result = {}
         snap_result["os.environ"] = dict(os.environ)
         snap_result["CFG"] = CFG
-        snap_result["sys.modules"] = {n:str(m) for (n,m) in sys.modules.iteritems()}
+        #snap_result["sys.modules"] = {n:str(m) for (n,m) in sys.modules.iteritems()}
         snap_result["sys.path"] = sys.path
 
         return snap_result

--- a/pyon/container/snapshot.py
+++ b/pyon/container/snapshot.py
@@ -151,6 +151,7 @@ class ContainerSnapshot(object):
                                        proc_start_time=getattr(proc, "_proc_start_time", ""),
                                        proc_svc_id=getattr(proc, "_proc_svc_id", ""),
                                        resource_id=getattr(proc, "resource_id", ""),
+                                       resource_type=getattr(proc, "resource_type", ""),
                                        time_stats=proc._process.time_stats
                                   )
 
@@ -158,40 +159,8 @@ class ContainerSnapshot(object):
 
     def _snap_policy(self, **kwargs):
         gov_ctrl = self.container.governance_controller
-        policies = gov_ctrl.get_active_policies()
-        snap_result = {}
-
-        common_list = []
-        snap_result["common_pdp"] = common_list
-        for rule in policies.get("common_service_access", {}).policy.rules:
-            rule_dict = dict(id=rule.id, description=rule.description, effect=rule.effect.value)
-            common_list.append(rule_dict)
-
-        service_dict = {}
-        snap_result["service_pdp"] = service_dict
-        for (svc_name, sp) in policies.get("service_access", {}).iteritems():
-            for rule in sp.policy.rules:
-                if svc_name not in service_dict:
-                    service_dict[svc_name] = []
-                rule_dict = dict(id=rule.id, description=rule.description, effect=rule.effect.value)
-                service_dict[svc_name].append(rule_dict)
-
-        service_pre_dict = {}
-        snap_result["service_precondition"] = service_pre_dict
-        for (svc_name, sp) in policies.get("service_operation", {}).iteritems():
-            for op, f in sp.iteritems():
-                if svc_name not in service_pre_dict:
-                    service_pre_dict[svc_name] = []
-                service_pre_dict[svc_name].append(op)
-
-        resource_dict = {}
-        snap_result["resource_pdp"] = resource_dict
-        for (res_name, sp) in policies.get("resource_access", {}).iteritems():
-            for rule in sp.policy.rules:
-                if res_name not in service_dict:
-                    resource_dict[res_name] = []
-                rule_dict = dict(id=rule.id, description=rule.description, effect=rule.effect.value)
-                resource_dict[res_name].append(rule_dict)
+        snap_result = gov_ctrl._get_policy_snapshot()
+        snap_result["update_log"] = gov_ctrl._policy_update_log
 
         return snap_result
 

--- a/pyon/container/snapshot.py
+++ b/pyon/container/snapshot.py
@@ -58,6 +58,7 @@ class ContainerSnapshot(object):
         cc_obj.status_log.insert(0, self.snapshot)
         cc_obj.status_log = cc_obj.status_log[:3]
         self.container.resource_registry.update(cc_obj)
+        return cc_id
 
     def log_snapshot(self):
         log.info("Container snapshot taken at %s" % self.snap_ts)
@@ -133,7 +134,7 @@ class ContainerSnapshot(object):
         from greenlet import greenlet
         greenlets = [obj for obj in gc.get_objects() if isinstance(obj, greenlet) and obj and not obj.dead]
         for ob in greenlets:
-            greenlet_list.append((getattr(ob, "kwargs", ""), ''.join(traceback.format_stack(ob.gr_frame))))
+            greenlet_list.append((getattr(ob, "_glname", ""), ''.join(traceback.format_stack(ob.gr_frame))))
         return snap_result
 
     def _snap_processes(self, **kwargs):

--- a/pyon/core/thread.py
+++ b/pyon/core/thread.py
@@ -64,6 +64,7 @@ class PyonThread(object):
         # Gevent spawn
         gl = spawn(self.target, *self.spawn_args, **self.spawn_kwargs)
         gl.link(lambda _: self.ev_exit.set())
+        gl._glname = "ION Thread %s" % str(self.target)
         return gl
 
     def _join(self, timeout=None):
@@ -92,6 +93,7 @@ class PyonThread(object):
 
     def start(self):
         self.proc = self._spawn()
+        self.proc._glname = "Container process supervisor"
         return self
 
     def notify_stop(self):

--- a/pyon/ion/event.py
+++ b/pyon/ion/event.py
@@ -239,6 +239,7 @@ class EventSubscriber(Subscriber, BaseEventSubscriberMixin):
         """
         assert not self._cbthread, "start called twice on EventSubscriber"
         gl = spawn(self.listen)
+        gl._glname = "EventSubscriber"
         self._cbthread = gl
         if not self._ready_event.wait(timeout=5):
             log.warning('EventSubscriber start timed out.')

--- a/pyon/ion/process.py
+++ b/pyon/ion/process.py
@@ -193,7 +193,9 @@ class IonProcessThread(PyonThread):
             else:
                 listen_thread_name          = "unknown-listener-%s" % (len(self.listeners)+1)
 
-            self._listener_map[listener]    = self.thread_manager.spawn(listener.listen, thread_name=listen_thread_name)
+            gl = self.thread_manager.spawn(listener.listen, thread_name=listen_thread_name)
+            gl.proc._glname = "ION Proc listener %s" % listen_thread_name
+            self._listener_map[listener] = gl
             self.listeners.append(listener)
         else:
             self._startup_listeners.append(listener)
@@ -230,6 +232,7 @@ class IonProcessThread(PyonThread):
 
         # spawn control flow loop
         self._ctrl_thread = self.thread_manager.spawn(self._control_flow)
+        self._ctrl_thread.proc._glname = "ION Proc CL %s" % self.name
 
         # wait on control flow loop, heartbeating as appropriate
         while not self._ctrl_thread.ev_exit.wait(timeout=self._heartbeat_secs):

--- a/pyon/ion/stream.py
+++ b/pyon/ion/stream.py
@@ -126,6 +126,7 @@ class StreamSubscriber(Subscriber):
         '''
         self.started = True
         self.greenlet = gevent.spawn(self.listen)
+        self.greenlet._glname = "StreamSubscriber"
 
     def stop(self):
         '''
@@ -217,6 +218,7 @@ class StandaloneStreamSubscriber(Subscriber):
         '''
         self.started = True
         self.greenlet = gevent.spawn(self.listen)
+        self.greenlet._glname = "StandaloneStreamSubscriber"
 
     def stop(self):
         '''

--- a/pyon/net/messaging.py
+++ b/pyon/net/messaging.py
@@ -375,6 +375,7 @@ def make_node(connection_params=None, name=None, timeout=None):
     conn_parameters = ConnectionParameters(host=connection_params["host"], virtual_host=connection_params["vhost"], port=connection_params["port"], credentials=credentials)
     connection = PyonSelectConnection(conn_parameters , node.on_connection_open)
     ioloop_process = gevent.spawn(ioloop, connection, name=name)
+    ioloop_process._glname = "pyon.net AMQP ioloop proc"
     #ioloop_process = gevent.spawn(connection.ioloop.start)
     node.ready.wait(timeout=timeout)
     return node, ioloop_process

--- a/pyon/net/transport.py
+++ b/pyon/net/transport.py
@@ -705,9 +705,11 @@ class LocalRouter(object):
         """
         self._queue_incoming = Queue()
         self._gl_msgs = self._gl_pool.spawn(self._run_gl_msgs)
+        self._gl_msgs._glname = "pyon.net AMQP msgs"
         self._gl_msgs.link_exception(self._child_failed)
 
         self.gl_ioloop = spawn(self._run_ioloop)
+        self.gl_ioloop._glname = "pyon.net AMQP ioloop"
 
     def stop(self):
         self._gl_msgs.kill()    # @TODO: better

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(  name = 'pyon',
             'python-gevent-profiler',
             'lxml==2.3.4', # Fails to compile on Linux ??!??
             'requests',
+            'psutil==1.0.1'
 
             # DM related dependencies for 'tables'
             # 'numpy==1.6.1',


### PR DESCRIPTION
DO NOT MERGE YET

This PR provides an extension to the container to dump a stats snapshot into its CapabilityContainer resource, based on a system management event. Stats include processes, policy, config, path, env variables, greenlets and other common variables.
