### PR TITLE
TEST - Adds stack trace to locals() in breakpoint for debug R2

### DIFF
--- a/pyon/util/breakpoint.py
+++ b/pyon/util/breakpoint.py
@@ -53,6 +53,7 @@ def breakpoint(scope=None, global_scope=None):
         from pyon.container.shell_api import get_shell_api
         from pyon.container.cc import Container
         locals().update(scope)
+        locals().update({'bt':get_stack})
         if Container.instance:
             locals().update(get_shell_api(Container.instance))
     if global_scope is not None:


### PR DESCRIPTION
This adds the ability to print and review the stack trace as a short hand "bt()" in the breakpoint. Really useful and it beats having to import stack trace from breakpoint.
