### PR TITLE
Patch int_test so not ALL os.kill gets mocked

### DIFF
--- a/pyon/container/cc.py
+++ b/pyon/container/cc.py
@@ -372,9 +372,11 @@ class Container(BaseContainerAgent):
 
         traceback.print_exc()
 
+        self._kill_fast()
+
+    def _kill_fast(self):
         # The exit code of the terminated process is set to non-zero
         os.kill(os.getpid(), signal.SIGTERM)
-
 
 class PidfileCapability(ContainerCapability):
     def start(self):

--- a/pyon/util/int_test.py
+++ b/pyon/util/int_test.py
@@ -139,7 +139,7 @@ class IonIntegrationTestCase(unittest.TestCase):
 #                main_gl.throw(AssertionError("Container.fail_fast trying to terminate OS process, preventing"))
 #            spawn(call_in_main_context, greenlet.getcurrent())
 
-        patcher = patch('pyon.container.cc.os.kill')        # , kill)
+        patcher = patch('pyon.container.cc.Container._kill_fast')
         patcher.start()
         self.addCleanup(patcher.stop)
 


### PR DESCRIPTION
Original test patch accidentally impacted code such as:
https://github.com/ooici/coi-services/blob/c24165f6cbce51ed5f358d20bb311224d873d28b/ion/agents/port/port_agent_process.py#L154
