### PR TITLE
OOIION-1753: Add pending channel numbers to Node for insulation

### DIFF
--- a/pyon/net/test/test_messaging.py
+++ b/pyon/net/test/test_messaging.py
@@ -363,6 +363,13 @@ class TestPyonSelectConnection(PyonTestCase):
 
         self.assertRaises(NoFreeChannels, self.conn._next_channel_number)
 
+    def text__next_channel_number_adds_to_pending(self):
+        ch = self.conn._next_channel_number()
+        self.assertIn(ch, self.conn._pending)
+
+        ch2 = self.conn._next_channel_number()
+        self.assertNotEquals(ch, ch2)
+
 @attr('INT')
 class TestNodeBInt(IonIntegrationTestCase):
     def setUp(self):
@@ -394,5 +401,4 @@ class TestNodeBInt(IonIntegrationTestCase):
         self.assertNotEquals(curpoolchids, [o.get_channel_id() for o in self.node._bidir_pool.itervalues()])
         self.assertNotIn(ch, self.node._bidir_pool.itervalues())
         self.assertIn(ch, self.node._dead_pool)
-
 


### PR DESCRIPTION
When requesting a channel number from Pika, when the correct set of circumstances leads to a channel not being fully allocated, our channel number selector wouldn't know about it but would cause Pika to crash, failing the container.

This adds a layer of insulation to ensure when a channel number is handed out, it won't be handed out again until it completes a round trip from Pika and gets wrapped by our AMQPTransport class.

This is to help solve the AMQCHAN IS NONE THIS SHOULD NEVER HAPPEN issues that occur from spurious greenlet interleaving with pika.
