### PR TITLE
CIDEVSTC-99 - WKT handling by datastore/Postgres

### DIFF
--- a/pyon/datastore/datastore_query.py
+++ b/pyon/datastore/datastore_query.py
@@ -40,10 +40,9 @@ class DatastoreQueryConst(object):
     GOP_WITHIN_BBOX = GOP_PREFIX + "within"
     GOP_CONTAINS_BBOX = GOP_PREFIX + "contains"
 
-    WKT_PREFIX = "wkt:"
-    WKT_OVERLAPS = WKT_PREFIX + "overlaps"
-    WKT_WITHIN = WKT_PREFIX + "within"
-    WKT_CONTAINS = WKT_PREFIX + "contains"
+    GOP_OVERLAPS_GEOM = GOP_PREFIX + "overlaps_geom"
+    GOP_WITHIN_GEOM = GOP_PREFIX + "within_geom"
+    GOP_CONTAINS_GEOM = GOP_PREFIX + "contains_geom"
 
     ROP_PREFIX = "rop:"
     ROP_OVERLAPS_RANGE = ROP_PREFIX + "overlaps"
@@ -190,20 +189,20 @@ class DatastoreQueryBuilder(DatastoreQueryConst):
 
     # --- Geospatial (WKT) operators
 
-    def overlaps_wkt(self, col, wkt, buf):
+    def overlaps_geom(self, col, wkt, buf):
         self._check_col(col)
         colname = col.split(":", 1)[1]
-        return self.op_expr(self.WKT_OVERLAPS, colname, wkt, buf)
+        return self.op_expr(self.GOP_OVERLAPS_GEOM, colname, wkt, buf)
 
-    def contains_wkt(self, col, wkt, buf):
+    def contains_geom(self, col, wkt, buf):
         self._check_col(col)
         colname = col.split(":", 1)[1]
-        return self.op_expr(self.WKT_CONTAINS, colname, wkt, buf)
+        return self.op_expr(self.GOP_CONTAINS_GEOM, colname, wkt, buf)
 
-    def within_wkt(self, col, wkt, buf):
+    def within_geom(self, col, wkt, buf):
         self._check_col(col)
         colname = col.split(":", 1)[1]
-        return self.op_expr(self.WKT_WITHIN, colname, wkt, buf)
+        return self.op_expr(self.GOP_WITHIN_GEOM, colname, wkt, buf)
 
     # --- Ordering
 

--- a/pyon/datastore/datastore_query.py
+++ b/pyon/datastore/datastore_query.py
@@ -40,6 +40,11 @@ class DatastoreQueryConst(object):
     GOP_WITHIN_BBOX = GOP_PREFIX + "within"
     GOP_CONTAINS_BBOX = GOP_PREFIX + "contains"
 
+    WKT_PREFIX = "wkt:"
+    WKT_OVERLAPS = WKT_PREFIX + "overlaps"
+    WKT_WITHIN = WKT_PREFIX + "within"
+    WKT_CONTAINS = WKT_PREFIX + "contains"
+
     ROP_PREFIX = "rop:"
     ROP_OVERLAPS_RANGE = ROP_PREFIX + "overlaps"
     ROP_WITHIN_RANGE = ROP_PREFIX + "within"
@@ -182,6 +187,23 @@ class DatastoreQueryBuilder(DatastoreQueryConst):
         self._check_col(col)
         colname = col.split(":", 1)[1]
         return self.op_expr(self.GOP_WITHIN_BBOX, colname, x1, y1, x2, y2)
+
+    # --- Geospatial (WKT) operators
+
+    def overlaps_wkt(self, col, wkt, buf):
+        self._check_col(col)
+        colname = col.split(":", 1)[1]
+        return self.op_expr(self.WKT_OVERLAPS, colname, wkt, buf)
+
+    def contains_wkt(self, col, wkt, buf):
+        self._check_col(col)
+        colname = col.split(":", 1)[1]
+        return self.op_expr(self.WKT_CONTAINS, colname, wkt, buf)
+
+    def within_wkt(self, col, wkt, buf):
+        self._check_col(col)
+        colname = col.split(":", 1)[1]
+        return self.op_expr(self.WKT_WITHIN, colname, wkt, buf)
 
     # --- Ordering
 

--- a/pyon/datastore/postgresql/pg_query.py
+++ b/pyon/datastore/postgresql/pg_query.py
@@ -23,6 +23,9 @@ class PostgresQueryBuilder(object):
               DQ.GOP_OVERLAPS_BBOX: "&&",
               DQ.GOP_CONTAINS_BBOX: "~",
               DQ.GOP_WITHIN_BBOX: "@",
+              DQ.WKT_OVERLAPS: "ST_Intersects(%s,%s)",
+              DQ.WKT_CONTAINS: "ST_Contains(%s,%s)",
+              DQ.WKT_WITHIN: "ST_Within(%s,%s)",
               DQ.ROP_OVERLAPS_RANGE: "&&",
               DQ.ROP_CONTAINS_RANGE: "@>",
               DQ.ROP_WITHIN_RANGE: "<@",
@@ -78,6 +81,14 @@ class PostgresQueryBuilder(object):
             colname, x1, y1, x2, y2 = args
             return "%s %s ST_MakeEnvelope(%s,%s,%s,%s,4326)" % (colname, self.OP_STR[op],
                     self._value(x1), self._value(y1), self._value(x2), self._value(y2))
+        elif op.startswith(DQ.WKT_PREFIX):
+            colname, wkt, buf = args
+            # PostGIS geometry from WKT http://postgis.net/docs/ST_GeomFromEWKT.html
+            geom_from_wkt = 'ST_GeomFromEWKT(\'SRID=4326;%s\')' % (wkt)
+            # if buffer specified, wrap geometry in buffer http://postgis.net/docs/ST_Buffer.html
+            if buf:
+                geom_from_wkt = 'ST_Buffer(%s, %f)' % (geom_from_wkt,float(buf))
+            return self.OP_STR[op] % (colname, geom_from_wkt)
         elif op == DQ.EXP_AND:
             return "(%s)" % " AND ".join(self._build_where(ex) for ex in args)
         elif op == DQ.EXP_OR:

--- a/pyon/datastore/postgresql/test/test_pg_query.py
+++ b/pyon/datastore/postgresql/test/test_pg_query.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+__author__ = 'Brian McKenna'
+__license__ = 'Apache 2.0'
+
+from nose.plugins.attrib import attr
+from unittest import SkipTest
+from mock import Mock, patch, ANY
+
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.util.unit_test import IonUnitTestCase
+
+from pyon.datastore.datastore_query import DatastoreQueryBuilder
+from pyon.datastore.postgresql.pg_query import PostgresQueryBuilder
+
+import interface.objects
+
+@attr('UNIT', group='datastore')
+class PostgresDataStoreUnitTest(IonUnitTestCase):
+
+    def test_wkt(self):
+        """ unit test to verify the DatastoreQuery to PostgresQuery to SQL translation for PostGIS WKT """
+        
+        wkt = 'POINT(-72.0 40.0)'
+        buf = 0.1
+        
+        # PostgresQueryBuilder - WKT (no buffer)
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.overlaps_wkt(qb.RA_GEOM_LOC,wkt,0.0))
+        pqb = PostgresQueryBuilder(qb.get_query(), 'test')
+        self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Intersects(geom_loc,ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'))")
+
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.contains_wkt(qb.RA_GEOM_LOC,wkt,0.0))
+        pqb = PostgresQueryBuilder(qb.get_query(), 'test')
+        self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Contains(geom_loc,ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'))")
+
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.within_wkt(qb.RA_GEOM_LOC,wkt,0.0))
+        pqb = PostgresQueryBuilder(qb.get_query(), 'test')
+        self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Within(geom_loc,ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'))")
+
+        # PostgresQueryBuilder - WKT (with buffer)
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.overlaps_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        pqb = PostgresQueryBuilder(qb.get_query(), 'test')
+        self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Intersects(geom_loc,ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'), 0.100000))")
+
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.contains_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        pqb = PostgresQueryBuilder(qb.get_query(), 'test')
+        self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Contains(geom_loc,ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'), 0.100000))")
+
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.within_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        pqb = PostgresQueryBuilder(qb.get_query(), 'test')
+        self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Within(geom_loc,ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'), 0.100000))")

--- a/pyon/datastore/postgresql/test/test_pg_query.py
+++ b/pyon/datastore/postgresql/test/test_pg_query.py
@@ -26,32 +26,32 @@ class PostgresDataStoreUnitTest(IonUnitTestCase):
         
         # PostgresQueryBuilder - WKT (no buffer)
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.overlaps_wkt(qb.RA_GEOM_LOC,wkt,0.0))
+        qb.build_query(where=qb.overlaps_geom(qb.RA_GEOM_LOC,wkt,0.0))
         pqb = PostgresQueryBuilder(qb.get_query(), 'test')
         self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Intersects(geom_loc,ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'))")
 
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.contains_wkt(qb.RA_GEOM_LOC,wkt,0.0))
+        qb.build_query(where=qb.contains_geom(qb.RA_GEOM_LOC,wkt,0.0))
         pqb = PostgresQueryBuilder(qb.get_query(), 'test')
         self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Contains(geom_loc,ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'))")
 
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.within_wkt(qb.RA_GEOM_LOC,wkt,0.0))
+        qb.build_query(where=qb.within_geom(qb.RA_GEOM_LOC,wkt,0.0))
         pqb = PostgresQueryBuilder(qb.get_query(), 'test')
         self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Within(geom_loc,ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'))")
 
         # PostgresQueryBuilder - WKT (with buffer)
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.overlaps_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        qb.build_query(where=qb.overlaps_geom(qb.RA_GEOM_LOC,wkt,buf))
         pqb = PostgresQueryBuilder(qb.get_query(), 'test')
         self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Intersects(geom_loc,ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'), 0.100000))")
 
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.contains_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        qb.build_query(where=qb.contains_geom(qb.RA_GEOM_LOC,wkt,buf))
         pqb = PostgresQueryBuilder(qb.get_query(), 'test')
         self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Contains(geom_loc,ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'), 0.100000))")
 
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.within_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        qb.build_query(where=qb.within_geom(qb.RA_GEOM_LOC,wkt,buf))
         pqb = PostgresQueryBuilder(qb.get_query(), 'test')
         self.assertEquals(pqb.get_query(),"SELECT id,doc FROM test WHERE ST_Within(geom_loc,ST_Buffer(ST_GeomFromEWKT('SRID=4326;POINT(-72.0 40.0)'), 0.100000))")

--- a/pyon/datastore/test/test_datastores.py
+++ b/pyon/datastore/test/test_datastores.py
@@ -37,16 +37,16 @@ class TestDataStoreUnitTest(IonUnitTestCase):
 
         # DatastoreQueryBuilder - WKT
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.overlaps_wkt(qb.RA_GEOM_LOC,wkt,buf))
-        self.assertEquals(qb.get_query()['where'], ['wkt:overlaps', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
+        qb.build_query(where=qb.overlaps_geom(qb.RA_GEOM_LOC,wkt,buf))
+        self.assertEquals(qb.get_query()['where'], ['gop:overlaps_geom', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
 
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.contains_wkt(qb.RA_GEOM_LOC,wkt,buf))
-        self.assertEquals(qb.get_query()['where'], ['wkt:contains', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
+        qb.build_query(where=qb.contains_geom(qb.RA_GEOM_LOC,wkt,buf))
+        self.assertEquals(qb.get_query()['where'], ['gop:contains_geom', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
 
         qb = DatastoreQueryBuilder()
-        qb.build_query(where=qb.within_wkt(qb.RA_GEOM_LOC,wkt,buf))
-        self.assertEquals(qb.get_query()['where'], ['wkt:within', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
+        qb.build_query(where=qb.within_geom(qb.RA_GEOM_LOC,wkt,buf))
+        self.assertEquals(qb.get_query()['where'], ['gop:within_geom', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
 
 @attr('INT', group='datastore')
 class TestDataStores(IonIntegrationTestCase):
@@ -886,12 +886,12 @@ class TestDataStores(IonIntegrationTestCase):
         self.assertEquals(len(res), 1)
 
         # two tests: first should NOT have above Site1 in radius, second should
-        qb = DatastoreQueryBuilder(where=qb.overlaps_wkt(qb.RA_GEOM,'POINT(2.0 2.0)',0.5))
+        qb = DatastoreQueryBuilder(where=qb.overlaps_geom(qb.RA_GEOM,'POINT(2.0 2.0)',0.5))
         qb.build_query()
         res = data_store.find_resources_mult(qb.get_query())
         self.assertEquals(len(res), 0)
         # -- additional 0.001 is to compensate for outer edge NOT being considered an overlap/intersect
-        qb = DatastoreQueryBuilder(where=qb.overlaps_wkt(qb.RA_GEOM,'POINT(2.0 2.0)',1.001))
+        qb = DatastoreQueryBuilder(where=qb.overlaps_geom(qb.RA_GEOM,'POINT(2.0 2.0)',1.001))
         qb.build_query()
         res = data_store.find_resources_mult(qb.get_query())
         self.assertEquals(len(res), 1)

--- a/pyon/datastore/test/test_datastores.py
+++ b/pyon/datastore/test/test_datastores.py
@@ -27,9 +27,29 @@ OWNER_OF = "XOWNER_OF"
 HAS_A = "XHAS_A"
 BASED_ON = "XBASED_ON"
 
-
 @attr('UNIT', group='datastore')
-class Test_DataStores(IonIntegrationTestCase):
+class TestDataStoreUnitTest(IonUnitTestCase):
+
+    def test_datastore_query_builder(self):
+
+        wkt = 'POINT(-72.0 40.0)'
+        buf = 0.1
+
+        # DatastoreQueryBuilder - WKT
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.overlaps_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        self.assertEquals(qb.get_query()['where'], ['wkt:overlaps', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
+
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.contains_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        self.assertEquals(qb.get_query()['where'], ['wkt:contains', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
+
+        qb = DatastoreQueryBuilder()
+        qb.build_query(where=qb.within_wkt(qb.RA_GEOM_LOC,wkt,buf))
+        self.assertEquals(qb.get_query()['where'], ['wkt:within', ('geom_loc', 'POINT(-72.0 40.0)', 0.1)])
+
+@attr('INT', group='datastore')
+class TestDataStores(IonIntegrationTestCase):
 
     def setUp(self):
         self.server_type = CFG.get_safe("container.datastore.default_server", "couchdb")
@@ -835,9 +855,6 @@ class Test_DataStores(IonIntegrationTestCase):
         res = self.data_store.create(ass_obj, create_unique_association_id())
         return res
 
-#@attr('UNIT', group='datastore')
-#class DataStoreUnitTest(IonUnitTestCase):
-
     def test_datastore_query(self):
         if self.server_type != "postgresql":
             raise SkipTest("find_resources_mult only works with Postgres")
@@ -856,14 +873,25 @@ class Test_DataStores(IonIntegrationTestCase):
         qb = DatastoreQueryBuilder()
         qb.build_query(where=qb.or_(qb.and_(qb.eq(qb.RA_NAME, "Buoy1"), qb.eq(qb.RA_NAME, "Buoy1")), qb.eq(qb.RA_NAME, "Buoy1")))
         res = data_store.find_resources_mult(qb.get_query())
-        print res
+        self.assertEquals(len(res), 1)
 
         qb = DatastoreQueryBuilder()
         qb.build_query(where=qb.and_(qb.like(qb.RA_NAME, "Si%"), qb.overlaps_bbox(qb.RA_GEOM, 1, -1.2, 4, 4)))
         res = data_store.find_resources_mult(qb.get_query())
-        print res
+        self.assertEquals(len(res), 1)
 
         qb = DatastoreQueryBuilder()
         qb.build_query(where=qb.attr_like("description", "My%"))
         res = data_store.find_resources_mult(qb.get_query())
-        print res
+        self.assertEquals(len(res), 1)
+
+        # two tests: first should NOT have above Site1 in radius, second should
+        qb = DatastoreQueryBuilder(where=qb.overlaps_wkt(qb.RA_GEOM,'POINT(2.0 2.0)',0.5))
+        qb.build_query()
+        res = data_store.find_resources_mult(qb.get_query())
+        self.assertEquals(len(res), 0)
+        # -- additional 0.001 is to compensate for outer edge NOT being considered an overlap/intersect
+        qb = DatastoreQueryBuilder(where=qb.overlaps_wkt(qb.RA_GEOM,'POINT(2.0 2.0)',1.001))
+        qb.build_query()
+        res = data_store.find_resources_mult(qb.get_query())
+        self.assertEquals(len(res), 1)


### PR DESCRIPTION
M112 T133 - WKT handling by datastore/Postgres

Implements a WKT string search capability to datastore/Postgres (using PostGIS)

Handles all valid WKT string and the concept of a circle with radius as a point with a buffer to desired radius. Example {'wkt':'POINT(-70 40)', 'buffer':1.0} creates a circle centered on 40N,70W with a radius of 1.0 degrees.
