### PR TITLE
OOIION 1386: Performance gains: move unicode handling out of validating_setattr

### DIFF
--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -462,13 +462,17 @@ class IonObjectDeserializer(IonObjectSerializationBase):
     def _transform(self, obj):
         # Note: This check to detect an IonObject is a bit risky (only type_)
         if isinstance(obj, dict) and "type_" in obj:
-            objc    = obj.copy()
-            type    = objc['type_'].encode('ascii')
+            objc  = obj
+            otype = objc['type_'].encode('ascii')   # Correct?
 
             # don't supply a dict - we want the object to initialize with all its defaults intact,
             # which preserves things like IonEnumObject and invokes the setattr behavior we want there.
-            ion_obj = self._obj_registry.new(type)
+            ion_obj = self._obj_registry.new(otype)
             for k, v in objc.iteritems():
+
+                # unicode translate to utf8
+                if isinstance(v, unicode):
+                    v = str(v.encode('utf8'))
 
                 # CouchDB adds _attachments and puts metadata in it
                 # in pyon metadata is in the document
@@ -482,6 +486,7 @@ class IonObjectDeserializer(IonObjectSerializationBase):
 
         return obj
 
+    deserialize = IonObjectSerializationBase.operate
 
 class IonObjectBlameDeserializer(IonObjectDeserializer):
 

--- a/pyon/core/object.py
+++ b/pyon/core/object.py
@@ -416,18 +416,16 @@ class IonObjectSerializer(IonObjectSerializationBase):
 
     Used by the codec interceptor and when being written to CouchDB.
     """
-
-    serialize = IonObjectSerializationBase.operate
-
     def _transform(self, obj):
         if isinstance(obj, IonObjectBase):
-            res = dict((k, v) for k, v in obj.__dict__.iteritems() if k in obj._schema or k in built_in_attrs)
+            res = {k:v for k, v in obj.__dict__.iteritems() if k in obj._schema or k in built_in_attrs}
             if not 'type_' in res:
                 res['type_'] = obj._get_type()
             return res
 
         return obj
 
+    serialize = IonObjectSerializationBase.operate
 
 class IonObjectBlameSerializer(IonObjectSerializer):
 

--- a/pyon/core/registry.py
+++ b/pyon/core/registry.py
@@ -161,14 +161,7 @@ class IonObjectRegistry(object):
                 from pyon.core.object import built_in_attrs
                 if name not in self._schema and name not in built_in_attrs:
                     raise AttributeError("'%s' object has no attribute '%s'" % (type(self).__name__, name))
-                def unicode_to_utf8(value):
-                    if isinstance(value, unicode):
-                        value = str(value.encode('utf8'))
-                    return value
-                def recursive_encoding(value):
-                    value = walk(value, unicode_to_utf8, 'key_value')
-                    return value
-                self.__dict__[name] = recursive_encoding(value)
+                self.__dict__[name] = value
 
             setattrmethod = validating_setattr
             setattr(clzz, "__setattr__", setattrmethod)

--- a/pyon/core/test/test_object.py
+++ b/pyon/core/test/test_object.py
@@ -8,6 +8,7 @@ from pyon.core.registry import IonObjectRegistry
 from pyon.core.bootstrap import IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 from nose.plugins.attrib import attr
+import unittest
 
 
 @attr('UNIT')
@@ -138,6 +139,7 @@ class ObjectTest(IonIntegrationTestCase):
         # Should work
         obj._validate
 
+    @unittest.skip("no more recursive encoding on set")
     def test_recursive_encoding(self):
         obj = self.registry.new('SampleObject')
         a_dict = {'1':u"♣ Temporal Domain ♥",


### PR DESCRIPTION
Now `validating_setattr` can safely be turned off.

We lose the ability to recursively transform unicode -> utf8 on set, such as in nested dicts/lists, but the need is not obvious - the boundary we care about most is in the IonObjectDeserializer, taking json from messaging or the datastore and turning it into IonObjects.

Roughly 25% speedup on its own, 50% speedup with `validating_setattr` disabled in configuration.
