### PR TITLE
CIDEVSTC-99 - M112 - support search radius in meters

### DIFF
--- a/pyon/datastore/postgresql/pg_query.py
+++ b/pyon/datastore/postgresql/pg_query.py
@@ -84,9 +84,9 @@ class PostgresQueryBuilder(object):
                 geom_from_wkt = 'ST_GeomFromEWKT(\'SRID=4326;%s\')' % (wkt)
                 # if buffer specified, wrap geometry in buffer http://postgis.net/docs/ST_Buffer.html
                 if buf:
-                    if buf.lower().endswith('km'):
+                    if buf.lower().endswith('m'):
                         geom_from_wkt = '%s::geography' % geom_from_wkt # in meters instead of CRS units
-                        buf = buf[:-2] # remove trailing 'km'
+                        buf = buf[:-1] # remove trailing 'm'
                     geom_from_wkt = 'ST_Buffer(%s, %f)' % (geom_from_wkt,float(buf))
                 return self.OP_STR[op] % (colname, geom_from_wkt)
             else:

--- a/pyon/datastore/postgresql/pg_query.py
+++ b/pyon/datastore/postgresql/pg_query.py
@@ -84,10 +84,13 @@ class PostgresQueryBuilder(object):
                 geom_from_wkt = 'ST_GeomFromEWKT(\'SRID=4326;%s\')' % (wkt)
                 # if buffer specified, wrap geometry in buffer http://postgis.net/docs/ST_Buffer.html
                 if buf:
-                    if buf.lower().endswith('m'):
-                        geom_from_wkt = '%s::geography' % geom_from_wkt # in meters instead of CRS units
-                        buf = buf[:-1] # remove trailing 'm'
-                    geom_from_wkt = 'ST_Buffer(%s, %f)' % (geom_from_wkt,float(buf))
+                    postgis_cast = '' # we may need to cast PostGIS geography back to PostGIS geometry
+                    if isinstance(buf,str):
+                        if buf.lower().endswith('m'):
+                            geom_from_wkt = '%s::geography' % geom_from_wkt # in meters instead of CRS units
+                            buf = buf[:-1] # remove trailing 'm'
+                            postgis_cast = '::geometry' # must be converted to PostGIS geometry for search/comparison
+                    geom_from_wkt = 'ST_Buffer(%s, %f)%s' % (geom_from_wkt,float(buf),postgis_cast)
                 return self.OP_STR[op] % (colname, geom_from_wkt)
             else:
                colname, x1, y1, x2, y2 = args

--- a/pyon/datastore/postgresql/pg_query.py
+++ b/pyon/datastore/postgresql/pg_query.py
@@ -84,6 +84,9 @@ class PostgresQueryBuilder(object):
                 geom_from_wkt = 'ST_GeomFromEWKT(\'SRID=4326;%s\')' % (wkt)
                 # if buffer specified, wrap geometry in buffer http://postgis.net/docs/ST_Buffer.html
                 if buf:
+                    if buf.lower().endswith('km'):
+                        geom_from_wkt = '%s::geography' % geom_from_wkt # in meters instead of CRS units
+                        buf = buf[:-2] # remove trailing 'km'
                     geom_from_wkt = 'ST_Buffer(%s, %f)' % (geom_from_wkt,float(buf))
                 return self.OP_STR[op] % (colname, geom_from_wkt)
             else:


### PR DESCRIPTION
If buffer value endswith('m'), the client has specified buffer in meters, WKT should be converted to its geographic representation (meters) and the buffer applied.

NOTE: the ST_ compare operators (contains, within, etc) require two geometry objects, so had to cast the buffered geography object back to geometry

@mmeisinger please review for merge

will push coi-services tests after merge and bump
